### PR TITLE
Fixed bug in e-puck proximity sensor angles.

### DIFF
--- a/src/plugins/robots/e-puck/simulator/epuck_entity.cpp
+++ b/src/plugins/robots/e-puck/simulator/epuck_entity.cpp
@@ -30,7 +30,7 @@ namespace argos {
 
    static const Real PROXIMITY_SENSOR_RING_ELEVATION       = 0.06f;
    static const Real PROXIMITY_SENSOR_RING_RADIUS          = BODY_RADIUS;
-   static const CRadians PROXIMITY_SENSOR_RING_START_ANGLE = CRadians((ARGOS_PI / 8.0f) * 0.5f);
+   static const CRadians PROXIMITY_SENSOR_RING_START_ANGLE = CRadians((2 * ARGOS_PI / 8.0f) * 0.5f);
    static const Real PROXIMITY_SENSOR_RING_RANGE           = 0.1f;
 
    static const CRadians LED_RING_START_ANGLE   = CRadians((ARGOS_PI / 8.0f) * 0.5f);


### PR DESCRIPTION
PROXIMITY_SENSOR_RING_START_ANGLE was previously calculated as CRadians((ARGOS_PI / 8.0f) * 0.5f). Since PI is equivalent to 180 degrees, this worked out as 11.25 degrees, however I believe the intention was to start at 22.5 degrees and then space the proximity sensors 45 degrees apart thereafter. The current implementation results in asymmetrical layout of the proximity sensors.

I've changed the code to now use 2 * PI instead (360), resulting in a starting angle of 22.5 degrees. The proximity sensors are now laid out symmetrically.