### PR TITLE
Added missing alpha value to pfColor in CQTOpenGLUserFunctions::SetColor()

### DIFF
--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.cpp
@@ -115,7 +115,8 @@ namespace argos {
       const GLfloat pfColor[]     = {
          c_color.GetRed()   / 255.0f,
          c_color.GetGreen() / 255.0f,
-         c_color.GetBlue()  / 255.0f
+         c_color.GetBlue()  / 255.0f,
+         1.0f
       };
       glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, DEFAULT_SPECULAR);
       glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, DEFAULT_SHININESS);


### PR DESCRIPTION
`glMaterialfv()` expects an RGBA value for `GL_AMBIENT_AND_DIFFUSE`. The alpha value was missing from `pfColor` in `CQTOpenGLUserFunctions::SetColor()`, which was causing intermittent rendering issues on my Mac (but not under Linux, for some reason).

Presumably, omitting the alpha value from `pfColor` means that `glMaterialfv()` will use some uninitialised value in memory, which would explain the intermittent results I observed.

I've set the alpha value to 1.0, to match every other usage of ` GL_AMBIENT_AND_DIFFUSE` in the ARGoS source code.