### PR TITLE
Make signals and slots between Widget and Lua Window compatible again

### DIFF
--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_lua_main_window.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_lua_main_window.cpp
@@ -404,10 +404,10 @@ namespace argos {
       addDockWidget(Qt::LeftDockWidgetArea, m_pcLuaFunctionDock);
       m_pcLuaFunctionDock->hide();
       /* Connect stuff */
-      connect(&(m_pcMainWindow->GetOpenGLWidget()), SIGNAL(EntitySelected(size_t)),
-              this, SLOT(HandleEntitySelection(size_t)));
-      connect(&(m_pcMainWindow->GetOpenGLWidget()), SIGNAL(EntityDeselected(size_t)),
-              this, SLOT(HandleEntityDeselection(size_t)));
+      connect(&(m_pcMainWindow->GetOpenGLWidget()), SIGNAL(EntitySelected(CEntity*)),
+              this, SLOT(HandleEntitySelection(CEntity*)));
+      connect(&(m_pcMainWindow->GetOpenGLWidget()), SIGNAL(EntityDeselected(CEntity*)),
+              this, SLOT(HandleEntityDeselection(CEntity*)));
    }
 
    /****************************************/
@@ -691,8 +691,8 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   void CQTOpenGLLuaMainWindow::HandleEntitySelection(size_t un_index) {
-      CComposableEntity* pcSelectedEntity = dynamic_cast<CComposableEntity*>(CSimulator::GetInstance().GetSpace().GetRootEntityVector()[un_index]);
+   void CQTOpenGLLuaMainWindow::HandleEntitySelection(CEntity* pc_entity) {
+      CComposableEntity* pcSelectedEntity = dynamic_cast<CComposableEntity*>(pc_entity);
       if(pcSelectedEntity != NULL) {
          bool bFound = false;
          m_unSelectedRobot = 0;
@@ -745,7 +745,7 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   void CQTOpenGLLuaMainWindow::HandleEntityDeselection(size_t) {
+   void CQTOpenGLLuaMainWindow::HandleEntityDeselection(CEntity* pc_entity) {
       disconnect(&(m_pcMainWindow->GetOpenGLWidget()), SIGNAL(StepDone(int)),
                  m_pcLuaVariableTree->model(), SLOT(Refresh(int)));
       disconnect(m_pcMainWindow, SIGNAL(ExperimentReset()),

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_lua_main_window.h
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_lua_main_window.h
@@ -14,6 +14,7 @@ namespace argos {
    class CQTOpenGLMainWindow;
    class CLuaController;
    class CComposableEntity;
+   class CEntity;
 }
 
 class QAction;
@@ -46,8 +47,8 @@ namespace argos {
       void CodeModified();
       void CheckLuaStatus(int n_step);
       void HandleMsgTableSelection();
-      void HandleEntitySelection(size_t un_index);
-      void HandleEntityDeselection(size_t);
+      void HandleEntitySelection(CEntity* pc_entity);
+      void HandleEntityDeselection(CEntity* pc_entity);
       void VariableTreeChanged();
       void FunctionTreeChanged();
 


### PR DESCRIPTION
Fixed issue with signals and slots between the QTOpenGL Widget and Lua Main Window classes