### PR TITLE
Allow the experiment to be passed in by XML object

### DIFF
--- a/src/core/simulator/simulator.cpp
+++ b/src/core/simulator/simulator.cpp
@@ -103,6 +103,19 @@ namespace argos {
    /****************************************/
    /****************************************/
 
+   void CSimulator::Load(ticpp::Document config) {
+      /* Build configuration tree */
+      m_tConfiguration = config;
+      m_tConfigurationRoot = *m_tConfiguration.FirstChildElement();
+      /* Init the experiment */
+      Init();
+      LOG.Flush();
+      LOGERR.Flush();
+   }
+
+   /****************************************/
+   /****************************************/
+
    void CSimulator::LoadExperiment() {
       /* Build configuration tree */
       m_tConfiguration.LoadFile(m_strExperimentConfigFileName);

--- a/src/core/simulator/simulator.cpp
+++ b/src/core/simulator/simulator.cpp
@@ -103,9 +103,9 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   void CSimulator::Load(ticpp::Document config) {
+   void CSimulator::Load(TConfigurationNode& t_tree) {
       /* Build configuration tree */
-      m_tConfiguration = config;
+      m_tConfiguration = t_tree;
       m_tConfigurationRoot = *m_tConfiguration.FirstChildElement();
       /* Init the experiment */
       Init();

--- a/src/core/simulator/simulator.h
+++ b/src/core/simulator/simulator.h
@@ -299,10 +299,11 @@ namespace argos {
       TConfigurationNode& GetConfigForController(const std::string& str_id);
 
       /**
-       * Loads the TinyXML Document. This should have the same structure as an ARGoS file
+       * Loads an already-parsed XML configuration tree.
+       * The tree should have the same structure as an ARGoS file.
        * The variable m_tConfigurationRoot is set here.
        */
-      void Load(ticpp::Document config);
+      void Load(TConfigurationNode& t_tree);
 
 
       /**

--- a/src/core/simulator/simulator.h
+++ b/src/core/simulator/simulator.h
@@ -299,6 +299,13 @@ namespace argos {
       TConfigurationNode& GetConfigForController(const std::string& str_id);
 
       /**
+       * Loads the TinyXML Document. This should have the same structure as an ARGoS file
+       * The variable m_tConfigurationRoot is set here.
+       */
+      void Load(ticpp::Document config);
+
+
+      /**
        * Loads the XML configuration file.
        * The XML configuration file is parsed by this function.
        * The variable m_tConfigurationRoot is set here.
@@ -355,13 +362,13 @@ namespace argos {
        * <li> the simulation clock exceeds the maximum value set in the XML;
        * <li> when CLoopFunctions::IsExperimentFinished() returns <tt>true</tt>.
        * </ul>
-       * @return <tt>true</tt> if the experiment has finished.       
+       * @return <tt>true</tt> if the experiment has finished.
        * @see GetMaxSimulationClock()
        * @see Terminate()
        * @see CLoopFunctions::IsExperimentFinished()
        */
       bool IsExperimentFinished() const;
-      
+
    private:
 
       void InitFramework(TConfigurationNode& t_tree);


### PR DESCRIPTION
 - gives C++ executables that launch argos more control
 - allows you to configure experiments programatically
- some trailing whitespace was removed from this file