### PR TITLE
prevent accessing of null pointer to RNG in differential drive actuator

### DIFF
--- a/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
@@ -134,8 +134,10 @@ namespace argos {
        * Throw away two RNG Gaussian calls to make sure the RNG sequence is the same after resetting
        * These two calls were used to pick the bias in Init()
        */
-      m_pcRNG->Gaussian(1.0, 0.0);
-      m_pcRNG->Gaussian(1.0, 0.0);
+      if(m_pcRNG) {
+         m_pcRNG->Gaussian(1.0, 0.0);
+         m_pcRNG->Gaussian(1.0, 0.0);
+      }
    }
    
    /****************************************/


### PR DESCRIPTION
Since RNG is only needed if noise is on, RNG is not New'd if there is no noise, but the Reset method accesses RNG without checking if it's null. This causes a segfault. This fixes it, but it may not be the way you'd like to fix it (maybe you would rather instantiate the RNG in either case).