### PR TITLE
enh(#92): Better diagnostics for physics engine entity transfer failures

### DIFF
--- a/src/core/simulator/space/space.cpp
+++ b/src/core/simulator/space/space.cpp
@@ -174,7 +174,7 @@ namespace argos {
       }
       /* If no engine can house the entity, bomb out */
       if(vecPotentialEngines.empty()) {
-         THROW_ARGOSEXCEPTION("No physics engine can house entity \"" << pcToAdd->GetId() << "\".");
+        THROW_ARGOSEXCEPTION("No physics engines available to house entity \"" << pcToAdd->GetId() << "\"@(" << cPos << ").");
       }
       /* If the entity is not movable, add the entity to all the matching engines */
       if(! c_entity.IsMovable()) {
@@ -183,14 +183,14 @@ namespace argos {
             bAdded |= vecPotentialEngines[i]->AddEntity(*pcToAdd);
          }
          if(!bAdded) {
-            THROW_ARGOSEXCEPTION("No physics engine can house entity \"" << pcToAdd->GetId() << "\".");
+           THROW_ARGOSEXCEPTION("No physics engine can house immovable entity \"" << pcToAdd->GetId() << "\"@(" << cPos << ").");
          }
       }
       /* If the entity is movable, only one engine can be associated to the embodied entity */
       else if(vecPotentialEngines.size() == 1) {
          /* Only one engine matches, bingo! */
          if(!vecPotentialEngines[0]->AddEntity(*pcToAdd)) {
-            THROW_ARGOSEXCEPTION("No physics engine can house entity \"" << pcToAdd->GetId() << "\".");
+           THROW_ARGOSEXCEPTION("Single matching physics engine cannot house movable entity \"" << pcToAdd->GetId()  << "\"@(" << cPos << ").");
          }
       }
       else {
@@ -199,7 +199,7 @@ namespace argos {
             if(vecPotentialEngines[i]->AddEntity(*pcToAdd)) return;
          }
          /* No engine can house the entity */
-         THROW_ARGOSEXCEPTION("No physics engine can house entity \"" << pcToAdd->GetId() << "\".");
+         THROW_ARGOSEXCEPTION("Multiple matching physics engines, but none can house entity \"" << pcToAdd->GetId() << "\".");
       }
    }
       


### PR DESCRIPTION
- For each type of failure, a unique exception string is now emitted, along with
  the exception, for help in diagnosing why an entity transfer between physics
  engines has occurred.