### PR TITLE
enh(#2): Const accessor functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cmake_install.cmake
 doinst.sh
 slack-desc
 TAGS
+.dir-locals.el

--- a/src/core/simulator/loop_functions.h
+++ b/src/core/simulator/loop_functions.h
@@ -180,6 +180,10 @@ namespace argos {
          return m_cSpace;
       }
 
+      inline const CSpace& GetSpace() const {
+        return m_cSpace;
+      }
+
       /**
        * Moves the entity to the wanted position and orientation.
        * @param c_entity The positional component of the entity to move.

--- a/src/core/simulator/space/space.cpp
+++ b/src/core/simulator/space/space.cpp
@@ -30,7 +30,7 @@ namespace argos {
       m_pcFloorEntity(NULL),
       m_ptPhysicsEngines(NULL),
       m_ptMedia(NULL) {}
-   
+
    /****************************************/
    /****************************************/
 
@@ -105,16 +105,14 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   CSpace::TMapPerType& CSpace::GetEntitiesByType(const std::string& str_type) {
-      TMapPerTypePerId::iterator itEntities = m_mapEntitiesPerTypePerId.find(str_type);
-      if (itEntities != m_mapEntitiesPerTypePerId.end()){
-         return itEntities->second;
-      }
-      else {
-         THROW_ARGOSEXCEPTION("Entity map for type \"" << str_type << "\" not found.");
-      }
+   CSpace::TMapPerType& CSpace::GetEntitiesByTypeImpl(const std::string& str_type) const {
+     TMapPerTypePerId::const_iterator itEntities = m_mapEntitiesPerTypePerId.find(str_type);
+     if(itEntities != m_mapEntitiesPerTypePerId.end()){
+       return const_cast<CSpace::TMapPerType&>(itEntities->second);
+     } else {
+       THROW_ARGOSEXCEPTION("Entity map for type \"" << str_type << "\" not found.");
+     }
    }
-
    /****************************************/
    /****************************************/
 
@@ -156,7 +154,7 @@ namespace argos {
          m_vecControllableEntities.erase(it);
       }
    }
-      
+
    /****************************************/
    /****************************************/
 
@@ -216,7 +214,7 @@ namespace argos {
          THROW_ARGOSEXCEPTION(ossMsg.str());
       }
    }
-      
+
    /****************************************/
    /****************************************/
 

--- a/src/core/simulator/space/space.h
+++ b/src/core/simulator/space/space.h
@@ -140,7 +140,7 @@ namespace argos {
       /**
        * Returns the entity with the given id.
        * @param str_id The id of the wanted entity
-       * @return The entity with the given id.       
+       * @return The entity with the given id.
        * @throws CARGoSException if an entity with the wanted id does not exist
        */
       inline CEntity& GetEntity(const std::string& str_id) {
@@ -157,7 +157,7 @@ namespace argos {
        * The pattern must be a valid regexp.
        * @param t_buffer A vector filled with all the entities that match the given pattern.
        * @param str_pattern The pattern to match.
-       * @return The entity with the given id.       
+       * @return The entity with the given id.
        * @throws CARGoSException if the regexp is not valid.
        */
       void GetEntitiesMatching(CEntity::TVector& t_buffer,
@@ -208,7 +208,14 @@ namespace argos {
        * @see TMapPerType
        * @see GetEntityMapPerTypePerId()
        */
-      TMapPerType& GetEntitiesByType(const std::string& str_type);
+
+      TMapPerType& GetEntitiesByType(const std::string& str_type) {
+        return GetEntitiesByTypeImpl(str_type);
+      }
+
+      const TMapPerType& GetEntitiesByType(const std::string& str_type) const {
+        return GetEntitiesByTypeImpl(str_type);
+      }
 
       /**
        * Returns the floor entity.
@@ -392,7 +399,7 @@ namespace argos {
       virtual void AddControllableEntity(CControllableEntity& c_entity);
       virtual void RemoveControllableEntity(CControllableEntity& c_entity);
       virtual void AddEntityToPhysicsEngine(CEmbodiedEntity& c_entity);
-      
+
    protected:
 
       virtual void UpdateControllableEntitiesAct() = 0;
@@ -452,6 +459,9 @@ namespace argos {
 
       /** A pointer to the list of media */
       CMedium::TVector* m_ptMedia;
+
+  private:
+      TMapPerType& GetEntitiesByTypeImpl(const std::string& str_type) const;
    };
 
    /****************************************/

--- a/src/plugins/robots/foot-bot/simulator/footbot_entity.h
+++ b/src/plugins/robots/foot-bot/simulator/footbot_entity.h
@@ -56,9 +56,13 @@ namespace argos {
       virtual void Init(TConfigurationNode& t_tree);
       virtual void Reset();
       virtual void UpdateComponents();
-      
+
       inline CControllableEntity& GetControllableEntity() {
          return *m_pcControllableEntity;
+      }
+
+      inline const CControllableEntity& GetControllableEntity() const {
+        return *m_pcControllableEntity;
       }
 
       inline CFootBotDistanceScannerEquippedEntity& GetDistanceScannerEquippedEntity() {


### PR DESCRIPTION
- Added so that lists of entities of a given type are also available in `const`-qualified loop functions without extensive use of const_cast. Similarly for exposing a `const` way to obtain a handle on the robot controller for a footbot entity.

- Existing ARGoS functionality should not be affected, as these changes only add `const`-ness, where before only the non-`const` versions were available.