### PR TITLE
enh(#6): Toggle for foot-bot light sensor

### DIFF
--- a/src/plugins/robots/foot-bot/control_interface/ci_footbot_light_sensor.h
+++ b/src/plugins/robots/foot-bot/control_interface/ci_footbot_light_sensor.h
@@ -81,6 +81,10 @@ namespace argos {
       virtual void ReadingsToLuaState(lua_State* pt_lua_state);
 #endif
 
+     virtual void Enable() = 0;
+
+     virtual void Disable() = 0;
+
    protected:
 
       TReadings m_tReadings;

--- a/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
@@ -52,6 +52,7 @@ namespace argos {
    /****************************************/
 
    CFootBotLightRotZOnlySensor::CFootBotLightRotZOnlySensor() :
+      m_bEnabled(false),
       m_pcEmbodiedEntity(NULL),
       m_bShowRays(false),
       m_pcRNG(NULL),
@@ -102,6 +103,9 @@ namespace argos {
    /****************************************/
    
    void CFootBotLightRotZOnlySensor::Update() {
+      if (!m_bEnabled) {
+        return;
+      }
       /* Erase readings */
       for(size_t i = 0; i < m_tReadings.size(); ++i) {
          m_tReadings[i].Value = 0.0f;
@@ -222,6 +226,20 @@ namespace argos {
       for(UInt32 i = 0; i < GetReadings().size(); ++i) {
          m_tReadings[i].Value = 0.0f;
       }
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CFootBotLightRotZOnlySensor::Enable() {
+     m_bEnabled = true;
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CFootBotLightRotZOnlySensor::Disable() {
+     m_bEnabled = false;
    }
 
    /****************************************/

--- a/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.h
+++ b/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.h
@@ -40,8 +40,14 @@ namespace argos {
 
       virtual void Reset();
 
+     void Enable();
+
+     void Disable();
+
    protected:
 
+      /** Is this sensor currently enabled? */
+      bool             m_bEnabled;
       /** Reference to embodied entity associated to this sensor */
       CEmbodiedEntity* m_pcEmbodiedEntity;
 


### PR DESCRIPTION
After doing some profiling, I've found that having robots have their light sensor updated every timestep was accounting for about 25% of simulation time, when they were only using it to return to the nest occasionally in my use case. So, by making it toggle-able, it can be turned on when needed, and the computation not be wasted when it is not going to be used that timestep by the robot.
