### PR TITLE
enh(#4): Make Lua code optional

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -175,6 +175,7 @@ The compilation of ARGoS can be configured through a set of CMake options:
 | +ARGOS_USE_DOUBLE+       | _BOOLEAN_ | Use +double+ (+ON+) or +float+ (+OFF+) [+ON+]
 | +ARGOS_DOCUMENTATION+    | _BOOLEAN_ | Create API documentation [+ON+]
 | +ARGOS_INSTALL_LDSOCONF+ | _BOOLEAN_ | Install the file +/etc/ld.so.conf/argos3.conf+ [+ON+ on Linux, +OFF+ on Mac]
+| +ARGOS_WITH_LUA          | _BOOLEAN_ | Enable Lua support if the required libraries and headers are found+ [+OFF+]
 |====================================================================================================================
 
 You can pass the wanted values from the command line. For instance, if you
@@ -190,6 +191,7 @@ wanted to set explictly all the default values, when compiling on Linux you woul
          -DARGOS_USE_DOUBLE=ON \
          -DARGOS_DOCUMENTATION=ON \
          -DARGOS_INSTALL_LDSOCONF=ON \
+         -DARGOS_WITH_LUA=OFF \
          ../src
 
 IMPORTANT: When +ARGOS_BUILD_FOR+ is set to +simulator+, +ARGOS_THREADSAFE_LOG+

--- a/src/cmake/ARGoSBuildChecks.cmake
+++ b/src/cmake/ARGoSBuildChecks.cmake
@@ -102,8 +102,12 @@ find_package(ASCIIDoc)
 #
 find_package(Lua52)
 if(LUA52_FOUND)
-  set(ARGOS_WITH_LUA ON)
-  include_directories(${LUA_INCLUDE_DIR})
+  if (NOT ARGOS_WITH_LUA)
+    message("-- Lua5.2 found but disabled by configuration")
+  else()
+    set(ARGOS_WITH_LUA ON)
+    include_directories(${LUA_INCLUDE_DIR})
+  endif(NOT ARGOS_WITH_LUA)
 endif(LUA52_FOUND)
 
 #

--- a/src/cmake/ARGoSBuildOptions.cmake
+++ b/src/cmake/ARGoSBuildOptions.cmake
@@ -73,3 +73,19 @@ endif(NOT DEFINED ARGOS_USE_DOUBLE)
 if(NOT DEFINED ARGOS_DOCUMENTATION)
   option(ARGOS_DOCUMENTATION "ON -> compile documentation, OFF -> dont'compile documentation" ON)
 endif(NOT DEFINED ARGOS_DOCUMENTATION)
+
+#
+# Should Lua support be compiled in if it is found?
+#
+if(NOT DEFINED ARGOS_WITH_LUA)
+  option(ARGOS_WITH_LUA "ON -> compile in Lua support, if the required libraries
+are found on the system, OFF -> dont'compile Lua support, even if the required
+libraries are found on the system" OFF)
+endif(NOT DEFINED ARGOS_WITH_LUA)
+
+# Configure CCache if available
+find_program(CCACHE_FOUND ccache)
+if (CCACHE_FOUND)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif()

--- a/src/core/config.h.in
+++ b/src/core/config.h.in
@@ -39,11 +39,6 @@
 #cmakedefine ARGOS_COMPILE_QTOPENGL
 
 /*
- * Whether ARGoS was compiled with GSL support
- */
-#cmakedefine ARGOS_WITH_GSL
-
-/*
  * Whether ARGoS was compiled with FreeImage support
  */
 #cmakedefine ARGOS_WITH_FREEIMAGE

--- a/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
@@ -100,7 +100,7 @@ namespace argos {
 
    /****************************************/
    /****************************************/
-   
+
    void CFootBotLightRotZOnlySensor::Update() {
       /* Erase readings */
       for(size_t i = 0; i < m_tReadings.size(); ++i) {
@@ -214,7 +214,7 @@ namespace argos {
          }
       }
    }
-      
+
    /****************************************/
    /****************************************/
 


### PR DESCRIPTION
- Makes including Lua support optional even if the required libraries are found,
  reducing binary size.