### PR TITLE
docs(#8): Query plugin documentation

### DIFF
--- a/src/plugins/robots/generic/simulator/battery_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/battery_default_sensor.cpp
@@ -104,9 +104,11 @@ namespace argos {
                    "Adhavan Jayabalan [jadhu94@gmail.com]",
                    "1.0",
                    "A generic battery level sensor.",
+
                    "This sensor returns the current battery level of a robot. This sensor\n"
                    "can be used with any robot, since it accesses only the body component. In\n"
                    "controllers, you must include the ci_battery_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"
                    "    ...\n"
@@ -121,7 +123,9 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to add uniform noise to the sensor, thus matching the\n"
                    "characteristics of a real robot better. You can add noise through the\n"
                    "attribute 'noise_range' as follows:\n\n"
@@ -138,9 +142,8 @@ namespace argos {
                    "      ...\n"
                    "    </my_controller>\n"
                    "    ...\n"
-                   "  </controllers>\n\n"
-                   "OPTIONAL XML CONFIGURATION\n\n"
-                   "None.\n",
+                   "  </controllers>\n\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/generic/simulator/camera_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/camera_default_sensor.cpp
@@ -245,6 +245,7 @@ namespace argos {
                    "cameras", "default",
                    "Michael Allwright [allsey87@gmail.com]",
                    "1.0",
+
                    "A generic multi-camera sensor capable of running various algorithms",
                    "The generic multi-camera sensor can be attached to any composable entity in\n"
                    "ARGoS that contains an embodied entity with at least one anchor. The sensor\n"
@@ -253,6 +254,7 @@ namespace argos {
                    "that algorithms can project a feature in the simulation on to the virtual\n"
                    "sensor and store its 2D pixel coordinates as a reading. The implementation\n"
                    "of algorithms that behave differently, however, is also possible.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"
                    "    ...\n"
@@ -267,11 +269,14 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to draw the frustum of each camera sensor in the OpenGL\n"
                    "visualization. This can be useful for sensor debugging but also to understand\n"
                    "what's wrong in your controller. To turn this functionality on, add the\n"
                    "attribute \"show_frustum\" as follows:\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -285,11 +290,13 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "To add a camera to the plugin, create a camera node as shown in the following\n"
                    "example. A camera is defined by its range (how close and how far the camera\n"
                    "can see), its anchor and its position and orientation offsets from that\n"
                    "that anchor, its focal length and principal point (which define the\n"
                    "projection matrix), and its resolution.\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -308,6 +315,7 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "To run an algorithm on the camera sensor, simply add the algorithm as a node\n"
                    "under the camera node. At the time of writing, three algorithms are available\n"
                    "by default: led_detector, directional_led_detector, and tag_detector. Each of\n"
@@ -315,6 +323,7 @@ namespace argos {
                    "target entities are indexed. By setting the show_rays attribute to true, you\n"
                    "can see whether or not a target was partially occluded by another object in\n"
                    "the simulation. For example:\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -335,5 +344,6 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n",
+
                    "Usable");
 }

--- a/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
@@ -238,12 +238,15 @@ namespace argos {
                    "colored_blob_omnidirectional_camera", "rot_z_only",
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
+
                    "A generic omnidirectional camera sensor to detect colored blobs.",
                    "This sensor accesses an omnidirectional camera that detects colored blobs. The\n"
                    "sensor returns a list of blobs, each defined by a color and a position with\n"
                    "respect to the robot reference point on the ground. In controllers, you must\n"
                    "include the ci_colored_blob_omnidirectional_camera_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -258,9 +261,12 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "The 'medium' attribute must be set to the id of the leds medium declared in the\n"
                    "<media> section.\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to draw the rays shot by the camera sensor in the OpenGL\n"
                    "visualization. This can be useful for sensor debugging but also to understand\n"
                    "what's wrong in your controller. In OpenGL, the rays are drawn in cyan when\n"
@@ -268,6 +274,7 @@ namespace argos {
                    "obstructed, a black dot is drawn where the intersection occurred.\n"
                    "To turn this functionality on, add the attribute \"show_rays\" as in this\n"
                    "example:\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -283,6 +290,7 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "It is possible to add uniform noise to the blobs, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
                    "\"noise_std_dev\".\n\n"
@@ -300,7 +308,17 @@ namespace argos {
                    "      ...\n"
                    "    </my_controller>\n"
                    "    ...\n"
-                   "  </controllers>\n",
+                   "  </controllers>\n\n"
+
+                   "OPTIMIZATION HINTS\n\n"
+
+                   "1. For small swarms, enabling the sensor (and therefore causing ARGoS to\n"
+                   "   update its readings each timestep) unconditionally does not impact performance too\n"
+                   "   much. For large swarms, it can impact performance, and selectively\n"
+                   "   enabling/disabling the sensor according to when each individual robot needs it\n"
+                   "   (e.g., only when it is looking for an LED equipped entity) can increase performance\n"
+                   "   by only requiring ARGoS to update the readings on timesteps they will be used.\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.cpp
@@ -263,12 +263,15 @@ namespace argos {
                    "colored_blob_perspective_camera", "default",
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
+
                    "A generic perspective camera sensor to detect colored blobs.",
                    "This sensor accesses an perspective camera that detects colored blobs. The\n"
                    "sensor returns a list of blobs, each defined by a color and a position with\n"
                    "respect to the robot reference point on the ground. In controllers, you must\n"
                    "include the ci_colored_blob_perspective_camera_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -283,9 +286,12 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "The 'medium' attribute must be set to the id of the leds medium declared in the\n"
                    "<media> section.\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to draw the rays shot by the camera sensor in the OpenGL\n"
                    "visualization. This can be useful for sensor debugging but also to understand\n"
                    "what's wrong in your controller. In OpenGL, the rays are drawn in cyan when\n"
@@ -293,6 +299,7 @@ namespace argos {
                    "obstructed, a black dot is drawn where the intersection occurred.\n"
                    "To turn this functionality on, add the attribute \"show_rays\" as in this\n"
                    "example:\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -308,9 +315,11 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "It is possible to add uniform noise to the blobs, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
                    "\"noise_std_dev\".\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -326,6 +335,7 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n",
+
                    "Usable"
       );
 

--- a/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
@@ -150,9 +150,11 @@ REGISTER_ACTUATOR(CDifferentialSteeringDefaultActuator,
                   "Carlo Pinciroli [ilpincy@gmail.com]",
                   "1.0",
                   "The differential steering actuator.",
+
                   "This actuator controls the two wheels a differential steering robot. For a\n"
                   "complete description of its usage, refer to the\n"
                   "ci_differential_steering_actuator.h file.\n\n"
+
                   "REQUIRED XML CONFIGURATION\n\n"
                   "  <controllers>\n"
                   "    ...\n"
@@ -167,7 +169,9 @@ REGISTER_ACTUATOR(CDifferentialSteeringDefaultActuator,
                   "    </my_controller>\n"
                   "    ...\n"
                   "  </controllers>\n\n"
+
                   "OPTIONAL XML CONFIGURATION\n\n"
+
                   "It is possible to specify noisy speed in order to match the characteristics\n"
                   "of the real robot. For each wheel, the noise model is as follows:\n\n"
                   "w = ideal wheel actuation (as set in the controller)\n"
@@ -181,7 +185,8 @@ REGISTER_ACTUATOR(CDifferentialSteeringDefaultActuator,
                   "factor attributes are dimensionless. If none of these attributed is specified,\n"
                   "no noise is added. If at least one of these attributed is specified, noise is\n"
                   "added and, for the non-specified attributes, the default value of 1 is used for\n"
-                  "the '*_avg' attributes, while 0 is used for '*_stddev' attributes. Examples:\n\n" 
+                  "the '*_avg' attributes, while 0 is used for '*_stddev' attributes. Examples:\n\n"
+
                   "  <controllers>\n"
                   "    ...\n"
                   "    <my_controller ...>\n"
@@ -209,9 +214,11 @@ REGISTER_ACTUATOR(CDifferentialSteeringDefaultActuator,
                   "    </my_controller>\n"
                   "    ...\n"
                   "  </controllers>\n\n"
+
                   "The above examples set the same noise for both wheels. If you want to set\n"
                   "different noise parameters for each wheel, append '_left' and '_right' to the\n"
                   "attribute names:\n\n"
+
                   "  <controllers>\n"
                   "    ...\n"
                   "    <my_controller ...>\n"
@@ -231,6 +238,7 @@ REGISTER_ACTUATOR(CDifferentialSteeringDefaultActuator,
                   "    </my_controller>\n"
                   "    ...\n"
                   "  </controllers>\n\n"
+
                   "Wheel-specific attributes overwrite the values of non-wheel specific attributes.\n"
                   "So, if you set 'bias_avg' = 2 and then 'bias_avg_left' = 3, the left wheel will\n"
                   "use 3 and the right wheel will use 2.\n\n"
@@ -239,4 +247,3 @@ REGISTER_ACTUATOR(CDifferentialSteeringDefaultActuator,
                   "information.",
                   "Usable"
    );
-   

--- a/src/plugins/robots/generic/simulator/differential_steering_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/differential_steering_default_sensor.cpp
@@ -93,10 +93,13 @@ namespace argos {
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
                    "A generic differential steering sensor.",
+
                    "This sensor returns the current position and orientation of a robot. This sensor\n"
                    "can be used with any robot, since it accesses only the body component. In\n"
                    "controllers, you must include the ci_differential_steering_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -110,13 +113,16 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to add uniform noise to the sensor, thus matching the\n"
                    "characteristics of a real robot better. You can add noise through the\n"
                    "attributes 'vel_noise_range' and 'dist_noise_range'.\n"
                    "Attribute 'vel_noise_range' regulates the noise range on the velocity returned\n"
                    "by the sensor. Attribute 'dist_noise_range' sets the noise range on the\n"
                    "distance covered by the wheels.\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -131,9 +137,8 @@ namespace argos {
                    "      ...\n"
                    "    </my_controller>\n"
                    "    ...\n"
-                   "  </controllers>\n\n"
-                   "OPTIONAL XML CONFIGURATION\n\n"
-                   "None.\n",
+                   "  </controllers>\n\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/generic/simulator/directional_leds_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/directional_leds_default_actuator.cpp
@@ -59,8 +59,10 @@ namespace argos {
                      "Michael Allwright [allsey87@gmail.com]",
                      "1.0",
                      "The directional LEDs actuator.",
+
                      "This actuator controls a group of directional LEDs. For a complete description\n"
                      "of its usage, refer to the ci_leds_actuator.h file.\n\n"
+
                      "REQUIRED XML CONFIGURATION\n\n"
                      "  <controllers>\n"
                      "    ...\n"
@@ -75,9 +77,12 @@ namespace argos {
                      "    </my_controller>\n"
                      "    ...\n"
                      "  </controllers>\n\n"
+
                      "The 'medium' attribute sets the id of the LED medium declared in the <media>\n"
                      "XML section.\n\n"
+
                      "OPTIONAL XML CONFIGURATION\n\n"
+
                      "None.\n",
                      "Usable"
    );

--- a/src/plugins/robots/generic/simulator/gripper_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/gripper_default_actuator.cpp
@@ -48,8 +48,10 @@ REGISTER_ACTUATOR(CGripperDefaultActuator,
                   "Carlo Pinciroli [ilpincy@gmail.com]",
                   "1.0",
                   "The Gripper actuator.",
+
                   "This actuator controls a gripper. For a complete description of its\n"
                   "usage, refer to the ci_gripper_actuator.h file.\n\n"
+
                   "REQUIRED XML CONFIGURATION\n\n"
                   "  <controllers>\n"
                   "    ...\n"
@@ -64,8 +66,11 @@ REGISTER_ACTUATOR(CGripperDefaultActuator,
                   "    </my_controller>\n"
                   "    ...\n"
                   "  </controllers>\n\n"
+
                   "OPTIONAL XML CONFIGURATION\n\n"
+
                   "None.\n",
+
                   "Usable"
    );
 

--- a/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
@@ -66,7 +66,7 @@ namespace argos {
 
    /****************************************/
    /****************************************/
-   
+
    void CGroundRotZOnlySensor::Update() {
       /*
        * We make the assumption that the robot is rotated only wrt to Z
@@ -125,11 +125,13 @@ namespace argos {
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
                    "A generic ground sensor (optimized for 2D).",
+
                    "This sensor accesses a set of ground sensors. The sensors all return a value\n"
                    "between 0 and 1, where 0 means black and 1 means white. Depending on the type\n"
                    "of ground sensor, readings can either take 0 or 1 as value (bw sensors) or a\n"
                    "value in between (grayscale sensors). In controllers, you must include the\n"
                    "ci_ground_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"
                    "    ...\n"
@@ -144,7 +146,9 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to add uniform noise to the sensors, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
                    "\"noise_level\", whose allowed range is in [-1,1] and is added to the calculated\n"
@@ -162,9 +166,8 @@ namespace argos {
                    "      ...\n"
                    "    </my_controller>\n"
                    "    ...\n"
-                   "  </controllers>\n\n"
-                   "OPTIONAL XML CONFIGURATION\n\n"
-                   "None.\n",
+                   "  </controllers>\n\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/generic/simulator/leds_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/leds_default_actuator.cpp
@@ -73,9 +73,12 @@ REGISTER_ACTUATOR(CLEDsDefaultActuator,
                   "Carlo Pinciroli [ilpincy@gmail.com]",
                   "1.0",
                   "The LEDs actuator.",
+
                   "This actuator controls a group of LEDs. For a complete description of its\n"
                   "usage, refer to the ci_leds_actuator.h file.\n\n"
+
                   "REQUIRED XML CONFIGURATION\n\n"
+
                   "  <controllers>\n"
                   "    ...\n"
                   "    <my_controller ...>\n"
@@ -90,10 +93,14 @@ REGISTER_ACTUATOR(CLEDsDefaultActuator,
                   "    </my_controller>\n"
                   "    ...\n"
                   "  </controllers>\n\n"
+
                   "The 'medium' attribute sets the id of the LED medium declared in the <media>\n"
                   "XML section.\n\n"
+
                   "OPTIONAL XML CONFIGURATION\n\n"
+
                   "None.\n",
+
                   "Usable"
    );
 

--- a/src/plugins/robots/generic/simulator/light_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/light_default_sensor.cpp
@@ -168,6 +168,7 @@ namespace argos {
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
                    "A generic light sensor.",
+
                    "This sensor accesses a set of light sensors. The sensors all return a value\n"
                    "between 0 and 1, where 0 means nothing within range and 1 means the perceived\n"
                    "light saturates the sensor. Values between 0 and 1 depend on the distance of\n"
@@ -180,6 +181,7 @@ namespace argos {
                    "reading is calculated as the sum of the individual readings due to each light.\n"
                    "In other words, light wave interference is not taken into account. In\n"
                    "controllers, you must include the ci_light_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"
                    "    ...\n"
@@ -194,7 +196,9 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to draw the rays shot by the light sensor in the OpenGL\n"
                    "visualization. This can be useful for sensor debugging but also to understand\n"
                    "what's wrong in your controller. In OpenGL, the rays are drawn in cyan when\n"
@@ -216,10 +220,12 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "It is possible to add uniform noise to the sensors, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
                    "\"noise_level\", whose allowed range is in [-1,1] and is added to the calculated\n"
                    "reading. The final sensor reading is always normalized in the [0-1] range.\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -234,8 +240,17 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
-                   "OPTIONAL XML CONFIGURATION\n\n"
-                   "None.\n",
+
+                   "OPTIMIZATION HINTS\n\n"
+
+                   "1. For small swarms, enabling the light sensor (and therefore causing ARGoS to\n"
+                   "   update its readings each timestep) unconditionally does not impact performance too\n"
+                   "   much. For large swarms, it can impact performance, and selectively\n"
+                   "   enabling/disabling the light sensor according to when each individual robot needs it\n"
+                   "   (e.g., only when it is returning to the nest from foraging) can increase performance\n"
+                   "   by only requiring ARGoS to update the readings for a robot on the timesteps will be\n"
+                   "   used.\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/generic/simulator/magnets_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/magnets_default_actuator.cpp
@@ -78,13 +78,16 @@ namespace argos {
                      "Michael Allwright [allsey87@gmail.com]",
                      "1.0",
                      "The (electro)magnet actuator.",
+
                      "This actuator is used to modify the magnetic field of a magnet entity in the\n"
                      "simulation. A magnetic entity has a passive and an active field. The overall\n"
                      "field of a magnetic entity is calculated as:\n\n"
                      "  field = passive_field + (current x active_field)\n\n"
                      "This actuator allows you to set the current, a scalar multiplier of the active\n"
                      "field.\n\n"
+
                      "REQUIRED XML CONFIGURATION\n\n"
+
                      "  <controllers>\n"
                      "    ...\n"
                      "    <my_controller ...>\n"
@@ -98,8 +101,11 @@ namespace argos {
                      "    </my_controller>\n"
                      "    ...\n"
                      "  </controllers>\n\n"
+
                      "OPTIONAL XML CONFIGURATION\n\n"
+
                      "None.\n",
+
                      "Under development"
    );
 

--- a/src/plugins/robots/generic/simulator/positioning_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/positioning_default_sensor.cpp
@@ -88,9 +88,11 @@ namespace argos {
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
                    "A generic positioning sensor.",
+
                    "This sensor returns the current position and orientation of a robot. This sensor\n"
                    "can be used with any robot, since it accesses only the body component. In\n"
                    "controllers, you must include the ci_positioning_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"
                    "    ...\n"
@@ -105,7 +107,9 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to add uniform noise to the sensor, thus matching the\n"
                    "characteristics of a real robot better. You can add noise through the\n"
                    "attributes 'pos_noise_range', 'angle_noise_range', and 'axis_noise_range'.\n"
@@ -114,6 +118,7 @@ namespace argos {
                    "(values expressed in degrees). Attribute 'axis_noise_range' sets the noise for\n"
                    "the rotation axis. Angle and axis are used to calculate a quaternion, which is\n"
                    "the actual returned value for rotation.\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -130,8 +135,11 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "None.\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
@@ -142,12 +142,15 @@ namespace argos {
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
                    "A generic proximity sensor.",
+
                    "This sensor accesses a set of proximity sensors. The sensors all return a value\n"
                    "between 0 and 1, where 0 means nothing within range and 1 means an external\n"
                    "object is touching the sensor. Values between 0 and 1 depend on the distance of\n"
                    "the occluding object, and are calculated as value=exp(-distance). In\n"
                    "controllers, you must include the ci_proximity_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -161,7 +164,9 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to draw the rays shot by the proximity sensor in the OpenGL\n"
                    "visualization. This can be useful for sensor debugging but also to understand\n"
                    "what's wrong in your controller. In OpenGL, the rays are drawn in cyan when\n"
@@ -169,6 +174,7 @@ namespace argos {
                    "obstructed, a black dot is drawn where the intersection occurred.\n"
                    "To turn this functionality on, add the attribute \"show_rays\" as in this\n"
                    "example:\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -183,10 +189,12 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "It is possible to add uniform noise to the sensors, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
                    "\"noise_level\", whose allowed range is in [-1,1] and is added to the calculated\n"
                    "reading. The final sensor reading is always normalized in the [0-1] range.\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -201,6 +209,7 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/generic/simulator/quadrotor_position_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/quadrotor_position_default_actuator.cpp
@@ -111,10 +111,13 @@ REGISTER_ACTUATOR(CQuadRotorPositionDefaultActuator,
                   "Carlo Pinciroli [ilpincy@gmail.com]",
                   "1.0",
                   "The quadrotor position actuator.",
+
                   "This actuator controls the position of a quadrotor robot. For a\n"
                   "complete description of its usage, refer to the\n"
                   "ci_quadrotor_position_actuator.h file.\n\n"
+
                   "REQUIRED XML CONFIGURATION\n\n"
+
                   "  <controllers>\n"
                   "    ...\n"
                   "    <my_controller ...>\n"
@@ -128,7 +131,9 @@ REGISTER_ACTUATOR(CQuadRotorPositionDefaultActuator,
                   "    </my_controller>\n"
                   "    ...\n"
                   "  </controllers>\n\n"
+
                   "OPTIONAL XML CONFIGURATION\n\n"
+
                   "None for the time being.\n\n"
                   ,
                   "Usable"

--- a/src/plugins/robots/generic/simulator/quadrotor_speed_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/quadrotor_speed_default_actuator.cpp
@@ -92,10 +92,13 @@ REGISTER_ACTUATOR(CQuadRotorSpeedDefaultActuator,
                   "Carlo Pinciroli [ilpincy@gmail.com]",
                   "1.0",
                   "The quadrotor speed actuator.",
+
                   "This actuator controls the speed of a quadrotor robot. For a\n"
                   "complete description of its usage, refer to the\n"
                   "ci_quadrotor_speed_actuator.h file.\n\n"
+
                   "REQUIRED XML CONFIGURATION\n\n"
+
                   "  <controllers>\n"
                   "    ...\n"
                   "    <my_controller ...>\n"
@@ -109,8 +112,10 @@ REGISTER_ACTUATOR(CQuadRotorSpeedDefaultActuator,
                   "    </my_controller>\n"
                   "    ...\n"
                   "  </controllers>\n\n"
+
                   "OPTIONAL XML CONFIGURATION\n\n"
-                  "None for the time being.\n\n"
+
+                  "None.\n\n"
                   ,
                   "Usable"
    );

--- a/src/plugins/robots/generic/simulator/radios_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/radios_default_actuator.cpp
@@ -112,12 +112,14 @@ namespace argos {
                      "radios", "default",
                      "Michael Allwright [allsey87@gmail.com]",
                      "1.0",
+
                      "A generic radio actuator to send messages to nearby radios.",
                      "This radio actuator implementation allows an arbitary number of messages\n"
                      "containing an arbitary number of bytes to be sent to nearby radios. The\n" 
                      "implementation of this actuator is very basic and any concepts such as\n"
                      "throughput, addressing, or formatting of a message's contents is beyond the\n"
                      "scope of this actuator's implementation.\n\n"
+
                      "REQUIRED XML CONFIGURATION\n\n"
                      "  <controllers>\n"
                      "    ...\n"
@@ -132,10 +134,14 @@ namespace argos {
                      "    </my_controller>\n"
                      "    ...\n"
                      "  </controllers>\n\n"
+
                      "The 'medium' attribute sets the id of the radio medium declared in the <media>\n"
                      "XML section.\n\n"
+
                      "OPTIONAL XML CONFIGURATION\n\n"
+
                      "None.\n",
+
                      "Usable"
    );
 

--- a/src/plugins/robots/generic/simulator/radios_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/radios_default_sensor.cpp
@@ -93,13 +93,16 @@ namespace argos {
                    "radios", "default",
                    "Michael Allwright [allsey87@gmail.com]",
                    "1.0",
+
                    "A generic radio sensor to receive messages from nearby radios.",
                    "This radio sensor implementation allows an arbitary number of messages\n"
                    "containing an arbitary number of bytes to be received from nearby robots. The\n"
                    "implementation is very basic and any concepts such as throughput, addressing,\n"
                    "or formatting of a message's contents is beyond the scope of this sensor's\n"
                    "implementation\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -113,10 +116,14 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "The 'medium' attribute sets the id of the radio medium declared in the <media>\n"
                    "XML section.\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "None.\n",
+
                    "Usable"
    );
 

--- a/src/plugins/robots/generic/simulator/range_and_bearing_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/range_and_bearing_default_actuator.cpp
@@ -41,6 +41,7 @@ namespace argos {
                      "Carlo Pinciroli [ilpincy@gmail.com]",
                      "1.0",
                      "The range and bearing actuator.",
+
                      "This actuator allows robots to perform situated communication, i.e., a form of\n"
                      "wireless communication whereby the receiver also knows the location of the\n"
                      "sender with respect to its own frame of reference.\n"
@@ -48,7 +49,9 @@ namespace argos {
                      "the range-and-bearing sensor.\n"
                      "To use this actuator, in controllers you must include the\n"
                      "ci_range_and_bearing_actuator.h header.\n\n"
+
                      "REQUIRED XML CONFIGURATION\n\n"
+
                      "  <controllers>\n"
                      "    ...\n"
                      "    <my_controller ...>\n"
@@ -62,8 +65,11 @@ namespace argos {
                      "    </my_controller>\n"
                      "    ...\n"
                      "  </controllers>\n\n"
+
                      "OPTIONAL XML CONFIGURATION\n\n"
-                     "None for the time being.\n",
+
+                     "None.\n",
+
                      "Usable");
    
 }

--- a/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.cpp
@@ -164,6 +164,7 @@ namespace argos {
                    "Carlo Pinciroli [ilpincy@gmail.com]",
                    "1.0",
                    "The range-and-bearing sensor.",
+
                    "This sensor allows robots to perform situated communication, i.e., a form of\n"
                    "wireless communication whereby the receiver also knows the location of the\n"
                    "sender with respect to its own frame of reference.\n"
@@ -174,6 +175,7 @@ namespace argos {
                    "range-and-bearing actuator.\n"
                    "To use this sensor, in controllers you must include the\n"
                    "ci_range_and_bearing_sensor.h header.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"
                    "    ...\n"
@@ -189,15 +191,19 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "The 'medium' attribute must be set to the id of the range-and-bearing medium\n"
                    "declared in the <media> section.\n\n"
+
                    "OPTIONAL XML CONFIGURATION\n\n"
+
                    "It is possible to draw the rays shot by the range-and-bearing sensor in the\n"
                    "OpenGL visualization. This can be useful for sensor debugging but also to\n"
                    "understand what's wrong in your controller. In OpenGL, the rays are drawn in\n"
                    "cyan when two robots are communicating.\n"
                    "To turn this functionality on, add the attribute \"show_rays\" as in this\n"
                    "example:\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -213,6 +219,7 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "It is possible to add noise to the readings, thus matching the characteristics\n"
                    "of a real robot better. Noise is implemented as a random vector added to the\n"
                    "vector joining two communicating robots. For the random vector, the inclination\n"
@@ -220,6 +227,7 @@ namespace argos {
                    "and the length is drawn from a Gaussian distribution. The standard deviation of\n"
                    "the Gaussian distribution is expressed in meters and set by the user through\n"
                    "the attribute 'noise_std_dev' as shown in this example:\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -235,9 +243,11 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n\n"
+
                    "In addition, it is possible to specify the probability that a packet gets lost\n"
                    "even though the robot should have received it (i.e., packet dropping). To set\n"
                    "this probability, use the attribute 'packet_drop_prob' as shown in the example:\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"
@@ -253,6 +263,7 @@ namespace argos {
                    "    </my_controller>\n"
                    "    ...\n"
                    "  </controllers>\n" ,
+
                    "Usable");
    
 }

--- a/src/plugins/robots/generic/simulator/tags_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/tags_default_actuator.cpp
@@ -59,11 +59,14 @@ namespace argos {
                      "Michael Allwright [allsey87@gmail.com]",
                      "1.0",
                      "The tags actuator.",
+
                      "This actuator controls the payloads of a group of tags. The idea"
                      "is to represent an LCD screen that displays different tags. For a"
                      "complete description of its usage, refer to the ci_tags_actuator.h"
                      " file.\n\n"
+
                      "REQUIRED XML CONFIGURATION\n\n"
+
                      "  <controllers>\n"
                      "    ...\n"
                      "    <my_controller ...>\n"
@@ -77,8 +80,11 @@ namespace argos {
                      "    </my_controller>\n"
                      "    ...\n"
                      "  </controllers>\n\n"
+
                      "OPTIONAL XML CONFIGURATION\n\n"
+
                      "None.\n",
+
                      "Usable"
    );
 

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_engine.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_engine.cpp
@@ -192,7 +192,7 @@ namespace argos {
                f_t));
       }
    }
-   
+
    void CDynamics2DEngine::CheckIntersectionWithRay(TEmbodiedEntityIntersectionData& t_data,
                                                     const CRay3& c_ray) const {
       /* Query all hits along the ray */
@@ -258,6 +258,7 @@ namespace argos {
                            "A 2D dynamics physics engine.",
                            "This physics engine is a 2D dynamics engine based on the Chipmunk library\n"
                            "(http://code.google.com/p/chipmunk-physics) version 6.0.1.\n\n"
+
                            "REQUIRED XML CONFIGURATION\n\n"
                            "  <physics_engines>\n"
                            "    ...\n"
@@ -265,9 +266,10 @@ namespace argos {
                            "    ...\n"
                            "  </physics_engines>\n\n"
                            "The 'id' attribute is necessary and must be unique among the physics engines.\n"
-                           "It is used in the subsequent section <arena_physics> to assign entities to\n"
-                           "physics engines. If two engines share the same id, initialization aborts.\n\n"
+                           "If two engines share the same id, initialization aborts.\n\n"
+
                            "OPTIONAL XML CONFIGURATION\n\n"
+
                            "It is possible to set how many iterations this physics engine performs between\n"
                            "each simulation step. By default, this physics engine performs 10 steps every\n"
                            "two simulation steps. This means that, if the simulation step is 100ms, the\n"
@@ -276,27 +278,33 @@ namespace argos {
                            "the number of iterations, the temporal granularity of the solver increases and\n"
                            "with it its accuracy, at the cost of higher computational cost. To change the\n"
                            "number of iterations per simulation step use this syntax:\n\n"
+
                            "  <physics_engines>\n"
                            "    ...\n"
                            "    <dynamics2d id=\"dyn2d\"\n"
                            "                iterations=\"20\" />\n"
                            "    ...\n"
                            "  </physics_engines>\n\n"
+
                            "The plane of the physics engine can be translated on the Z axis, to simulate\n"
                            "for example hovering objects, such as flying robots. To translate the plane\n"
                            "2m up the Z axis, use the 'elevation' attribute as follows:\n\n"
+
                            "  <physics_engines>\n"
                            "    ...\n"
                            "    <dynamics2d id=\"dyn2d\"\n"
                            "                elevation=\"2.0\" />\n"
                            "    ...\n"
                            "  </physics_engines>\n\n"
+
                            "When not specified, the elevation is zero, which means that the plane\n"
                            "corresponds to the XY plane.\n\n"
+
                            "The friction parameters between the ground and movable boxes and cylinders can\n"
                            "be overridden. You can set both the linear and angular friction parameters.\n"
                            "The default value is 1.49 for each of them. To override the values, use this\n"
                            "syntax (all attributes are optional):\n\n"
+
                            "  <physics_engines>\n"
                            "    ...\n"
                            "    <dynamics2d id=\"dyn2d\"\n"
@@ -307,10 +315,12 @@ namespace argos {
                            "    </dynamics2d>\n"
                            "    ...\n"
                            "  </physics_engines>\n\n"
+
                            "For the the robots that use velocity-based control, such as ground robots with\n"
                            "the differential_steering actuator (e.g. the foot-bot and the e-puck), it is\n"
                            "possible to customize robot-specific attributes that set the maximum force and\n"
                            "torque the robot has. The syntax is as follows, taking a foot-bot as example:\n\n"
+
                            "  <arena ...>\n"
                            "    ...\n"
                            "    <foot-bot id=\"fb0\">\n"
@@ -323,30 +333,103 @@ namespace argos {
                            "    </foot-bot>\n"
                            "    ...\n"
                            "  </arena>\n\n"
+
                            "The attributes 'max_force' and 'max_torque' are both optional, and they take the\n"
                            "robot-specific default if not set. Check the code of the dynamics2d model of the\n"
                            "robot you're using to know the default values.\n\n"
-                           "By default, this engine uses the bounding-box tree method for collision shape\n"
-                           "indexing. This method is the default in Chipmunk and it works well most of the\n"
-                           "times. However, if you are running simulations with hundreds or thousands of\n"
-                           "identical robots, a different shape collision indexing is available: the spatial\n"
-                           "hash. The spatial hash is a grid stored in a hashmap. To get the max out of this\n"
-                           "indexing method, you must set two parameters: the cell size and the suggested\n"
-                           "minimum number of cells in the space. According to the documentation of\n"
-                           "Chipmunk, the cell size should correspond to the size of the bounding box of the\n"
-                           "most common object in the simulation; the minimum number of cells should be at\n"
-                           "least 10x the number of objects managed by the physics engine. To use this\n"
-                           "indexing method, use this syntax (all attributes are mandatory):\n\n"
+
+                           "Multiple physics engines can also be used. If multiple physics engines are used,\n"
+                           "the disjoint union of the area within the arena assigned to each engine must cover\n"
+                           "the entire arena without overlapping. If the entire arena is not covered,robots can\n"
+                           "\"escape\" the configured physics engines and cause a fatal exception (this is not an\n"
+                           "issue when a single physics engine is used, because the engine covers the entire arena\n"
+                           "by default). To use multiple physics engines, use the following syntax (all attributes\n"
+                           "are mandatory):\n\n"
+
                            "  <physics_engines>\n"
                            "    ...\n"
-                           "    <dynamics2d id=\"dyn2d\"\n"
-                           "      <spatial_hash cell_size=\"1.0\"\n"
-                           "                    cell_num=\"2.0\" />\n"
+                           "    <dynamics2d id=\"dyn2d0\"\n"
+                           "      <boundaries>\n"
+                           "        <top height=\"1.0\"/>\n"
+                           "        <botton height=\"0.0\"/>\n"
+                           "        <sides>\n"
+                           "          <vertex point=\"0.0, 0.0\"/>\n"
+                           "          <vertex point=\"4.0, 0.0\"/>\n"
+                           "          <vertex point=\"4.0, 4.0\"/>\n"
+                           "          <vertex point=\"0.0, 4.0\"/>\n"
+                           "        </sides>\n"
+                           "      </boundaries>\n"
+                           "    </dynamics2d>\n"
+                           "    <dynamics2d id=\"dyn2d1\"\n"
+                           "     ..."
                            "    </dynamics2d>\n"
                            "    ...\n"
-                           "  </physics_engines>\n"
+                           "  </physics_engines>\n\n"
+
+                           "'Top' and 'Bottom' attributes are more relevant for 3D physics engines, and should\n"
+                           "be generally set to 1.0 and 0.0, respectively, for 2D engines. A physics engine can\n"
+                           "be defined having any number of sides >= 3, as long as the sides from a closed\n"
+                           "polygon in the 2D plane (vertices must be declared in the XML file in\n"
+                           "counter-clockwise order).  In the above example, the physics engine \"dyn2d0\" is\n"
+                           "assigned to the area within the arena with lower left coordinates (0,0) and upper\n"
+                           "right coordinates (4,4) and verticle are specified in counter clockwise order: LL,\n"
+                           "LR, UR, UL.\n\n"
+
+                           "OPTIMIZATION HINTS\n\n"
+
+                           "1. A single physics engine is generally sufficient for small swarms (say <= 50\n"
+                           "   robots) within a reasonably small arena to obtain faster than real-time\n"
+                           "   performance with optimized code. For larger swarms and/or large arenas multiple\n"
+                           "   engines should be used for maximum performance.\n\n"
+
+
+                           "2. In general, using the same number of ARGoS threads as physics engines gives\n"
+                           "   maximum performance (1-thread per engine per CPU core).\n\n"
+
+                           "3. Using multiple engines in simulations with any of the following characteristics\n"
+                           "   generally incurs more overhead due to thread context switching than the\n"
+                           "   performance benefits from multiple engines:\n\n"
+
+                           "   - Small swarms\n"
+                           "   - Small arenas\n"
+                           "   - Less available ARGoS threads than assigned physics engines\n"
+                           "   - Less available CPU cores than assigned ARGoS threads\n\n"
+
+
+                           "4. A good starting strategy for physics engine boundary assignment is to assign\n"
+                           "   each physics engine the same amount of area within the arena. This will be\n"
+                           "   sufficient for most cases. Depending on the nature of the simulation, using\n"
+                           "   non-homogeneous physics engine sizes may yield increased performance. An example\n"
+                           "   would be a narrow hallway between larger open areas in the arena--the hallway\n"
+                           "   will likely experience increased robot density and assigning more physics\n"
+                           "   engines to that area than the relatively unpopulated open areas may increase\n"
+                           "   performance.\n\n"
+
+                           "5. By default, this engine uses the bounding-box tree method for collision shape\n"
+                           "   indexing. This method is the default in Chipmunk and it works well most of the\n"
+                           "   times. However, if you are running simulations with hundreds or thousands of\n"
+                           "   identical robots, a different shape collision indexing is available: the\n"
+                           "   spatial hash. The spatial hash is a grid stored in a hashmap. To get the max\n"
+                           "   out of this indexing method, you must set two parameters: the cell size and the\n"
+                           "   suggested minimum number of cells in the space. According to the documentation\n"
+                           "   of Chipmunk, the cell size should correspond to the size of the bounding box of\n"
+                           "   the most common object in the simulation; the minimum number of cells should be\n"
+                           "   at least 10x the number of objects managed by the physics engine. To use\n"
+                           "   this indexing method, use this syntax (all attributes are mandatory):\n\n"
+
+                           "   <physics_engines>\n"
+                           "     ...\n"
+                           "     <dynamics2d id=\"dyn2d\">\n"
+                           "       <spatial_hash>\n"
+                           "         <cell_size=\"1.0\"/>\n"
+                           "         <cell_num=\"2.0\"/>\n"
+                           "       </spatial_hash>\n"
+                           "     </dynamics2d>\n"
+                           "     ...\n"
+                           "   </physics_engines>\n"
                            ,
+
                            "Usable"
-      );
+                           );
 
 }

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
@@ -134,7 +134,7 @@ namespace argos {
          m_cWorld.getMultiBodyConstraint(i)->finalizeMultiDof();
       }
    }
-   
+
    /****************************************/
    /****************************************/
 
@@ -168,7 +168,7 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   void CDynamics3DEngine::Update() {      
+   void CDynamics3DEngine::Update() {
       /* Update the physics state from the entities */
       for(CDynamics3DModel::TMap::iterator it = m_tPhysicsModels.begin();
           it != std::end(m_tPhysicsModels); ++it) {
@@ -190,22 +190,22 @@ namespace argos {
          m_cWorld.serialize(&cSerializer);
          std::ofstream cDebugOutput(m_strDebugFilename);
          if(cDebugOutput.is_open()) {
-            cDebugOutput.write(reinterpret_cast<const char*>(cSerializer.getBufferPointer()), 
+            cDebugOutput.write(reinterpret_cast<const char*>(cSerializer.getBufferPointer()),
                                cSerializer.getCurrentBufferSize());
          }
       }
    }
-   
+
    /****************************************/
    /****************************************/
-   
+
    void CDynamics3DEngine::CheckIntersectionWithRay(TEmbodiedEntityIntersectionData& t_data,
                                                     const CRay3& c_ray) const {
       /* Convert the start and end ray vectors to the bullet coordinate system */
       btVector3 cRayStart(c_ray.GetStart().GetX(), c_ray.GetStart().GetZ(), -c_ray.GetStart().GetY());
       btVector3 cRayEnd(c_ray.GetEnd().GetX(), c_ray.GetEnd().GetZ(), -c_ray.GetEnd().GetY());
       btCollisionWorld::ClosestRayResultCallback cResult(cRayStart, cRayEnd);
-      /* The default flag/algorithm 'kF_UseSubSimplexConvexCastRaytest' is too approximate for 
+      /* The default flag/algorithm 'kF_UseSubSimplexConvexCastRaytest' is too approximate for
          our purposes */
       cResult.m_flags |= btTriangleRaycastCallback::kF_UseGjkConvexCastRaytest;
       /* Run the ray test */
@@ -221,11 +221,11 @@ namespace argos {
 
    /****************************************/
    /****************************************/
-   
+
    size_t CDynamics3DEngine::GetNumPhysicsModels() {
       return m_tPhysicsModels.size();
    }
-     
+
    /****************************************/
    /****************************************/
 
@@ -245,7 +245,7 @@ namespace argos {
          (*this, c_entity);
       return cOutcome.Value;
    }
-  
+
    /****************************************/
    /****************************************/
 
@@ -283,7 +283,7 @@ namespace argos {
          m_tPhysicsModels.erase(itModel);
       }
       else {
-         THROW_ARGOSEXCEPTION("The model \"" << str_id << 
+         THROW_ARGOSEXCEPTION("The model \"" << str_id <<
                               "\" was not found in the dynamics 3D engine \"" <<
                               GetId() << "\"");
       }
@@ -307,8 +307,8 @@ namespace argos {
          m_tPhysicsPlugins.erase(it);
       }
       else {
-         THROW_ARGOSEXCEPTION("The plugin \"" << str_id << 
-                              "\" was not found in the dynamics 3D engine \"" << 
+         THROW_ARGOSEXCEPTION("The plugin \"" << str_id <<
+                              "\" was not found in the dynamics 3D engine \"" <<
                               GetId() << "\"");
       }
    }
@@ -323,21 +323,26 @@ namespace argos {
                            "A 3D dynamics physics engine",
                            "This physics engine is a 3D dynamics engine based on the Bullet Physics SDK\n"
                            "(https://github.com/bulletphysics/bullet3).\n\n"
+
                            "REQUIRED XML CONFIGURATION\n\n"
                            "  <physics_engines>\n"
                            "    ...\n"
                            "    <dynamics3d id=\"dyn3d\" />\n"
                            "    ...\n"
                            "  </physics_engines>\n\n"
+
                            "The 'id' attribute is necessary and must be unique among the physics engines.\n\n"
+
                            "OPTIONAL XML CONFIGURATION\n\n"
+
                            "It is possible to change the default friction used in the simulation from\n"
                            "its initial value of 1.0 using the default_friction attribute as shown\n"
                            "below. For debugging purposes, it is also possible to provide a filename\n"
                            "via the debug_file attribute which will cause the Bullet world to be\n"
-                           "serialized and written out to a file at the end of each step. This file\n"
-                           "can then be opened using the Bullet example browser and can provide useful\n"
+                           "serialized and written out to a file at the end of each step. This file can\n"
+                           "then be opened using the Bullet example browser and can provide useful\n"
                            "insights into the stability of a simulation.\n\n"
+
                            "  <physics_engines>\n"
                            "    ...\n"
                            "    <dynamics3d id=\"dyn3d\"\n"
@@ -345,6 +350,7 @@ namespace argos {
                            "                debug_file=\"dynamics3d.bullet\"/>\n"
                            "    ...\n"
                            "  </physics_engines>\n\n"
+
                            "The physics engine supports a number of plugins that add features to the\n"
                            "simulation. In the example below, a floor plane has been added which has a\n"
                            "height of 1 cm and the dimensions of the floor as specified by the arena\n"
@@ -358,6 +364,7 @@ namespace argos {
                            "'max_distance' attribute is an optional optimization that sets the maximum\n"
                            "distance at which two magnetic dipoles will interact with each other. In\n"
                            "the example below, this distance has been set to 4 cm.\n\n"
+
                            "  <physics_engines>\n"
                            "    ...\n"
                            "    <dynamics3d id=\"dyn3d\" default_friction=\"2.0\">\n"
@@ -367,6 +374,7 @@ namespace argos {
                            "    </dynamics3d>\n"
                            "    ...\n"
                            "  </physics_engines>\n\n",
+
                            "Usable"
       );
 

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_shape_manager.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_shape_manager.cpp
@@ -18,17 +18,17 @@ namespace argos {
 
    /****************************************/
    /****************************************/
-   
+
    std::shared_ptr<btCollisionShape> CDynamics3DShapeManager::RequestBox(const btVector3& c_half_extents) {
-      std::vector<SBoxResource>::iterator itBoxResource;      
+      std::vector<SBoxResource>::iterator itBoxResource;
       for(itBoxResource = std::begin(m_vecBoxResources);
           itBoxResource != std::end(m_vecBoxResources);
           ++itBoxResource) {
          if(itBoxResource->HalfExtents == c_half_extents) break;
-      }      
+      }
       /* If the resource doesn't exist, create a new one */
       if(itBoxResource == std::end(m_vecBoxResources)) {
-         itBoxResource = 
+         itBoxResource =
             m_vecBoxResources.emplace(itBoxResource, c_half_extents);
       }
       return std::static_pointer_cast<btCollisionShape>(itBoxResource->Shape);
@@ -37,7 +37,7 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   CDynamics3DShapeManager::SBoxResource::SBoxResource(const btVector3& c_half_extents) : 
+   CDynamics3DShapeManager::SBoxResource::SBoxResource(const btVector3& c_half_extents) :
       HalfExtents(c_half_extents),
       Shape(new btBoxShape(c_half_extents)) {}
 
@@ -49,17 +49,17 @@ namespace argos {
 
    /****************************************/
    /****************************************/
-   
+
    std::shared_ptr<btCollisionShape> CDynamics3DShapeManager::RequestCylinder(const btVector3& c_half_extents) {
-      std::vector<SCylinderResource>::iterator itCylinderResource;      
+      std::vector<SCylinderResource>::iterator itCylinderResource;
       for(itCylinderResource = std::begin(m_vecCylinderResources);
           itCylinderResource != std::end(m_vecCylinderResources);
           ++itCylinderResource) {
          if(itCylinderResource->HalfExtents == c_half_extents) break;
-      }      
+      }
       /* If the resource doesn't exist, create a new one */
       if(itCylinderResource == std::end(m_vecCylinderResources)) {
-         itCylinderResource = 
+         itCylinderResource =
             m_vecCylinderResources.emplace(itCylinderResource, c_half_extents);
       }
       return std::static_pointer_cast<btCollisionShape>(itCylinderResource->Shape);
@@ -68,29 +68,29 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   CDynamics3DShapeManager::SCylinderResource::SCylinderResource(const btVector3& c_half_extents) : 
+   CDynamics3DShapeManager::SCylinderResource::SCylinderResource(const btVector3& c_half_extents) :
       HalfExtents(c_half_extents),
       Shape(new btCylinderShape(c_half_extents)) {}
 
    /****************************************/
    /****************************************/
 
-   std::vector<CDynamics3DShapeManager::SSphereResource> 
+   std::vector<CDynamics3DShapeManager::SSphereResource>
       CDynamics3DShapeManager::m_vecSphereResources;
 
    /****************************************/
    /****************************************/
-   
+
    std::shared_ptr<btCollisionShape> CDynamics3DShapeManager::RequestSphere(btScalar f_radius) {
-      std::vector<SSphereResource>::iterator itSphereResource;      
+      std::vector<SSphereResource>::iterator itSphereResource;
       for(itSphereResource = std::begin(m_vecSphereResources);
           itSphereResource != std::end(m_vecSphereResources);
           ++itSphereResource) {
          if(itSphereResource->Radius == f_radius) break;
-      }      
+      }
       /* If the resource doesn't exist, create a new one */
       if(itSphereResource == std::end(m_vecSphereResources)) {
-         itSphereResource = 
+         itSphereResource =
             m_vecSphereResources.emplace(itSphereResource, f_radius);
       }
       return std::static_pointer_cast<btCollisionShape>(itSphereResource->Shape);
@@ -99,21 +99,21 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   CDynamics3DShapeManager::SSphereResource::SSphereResource(btScalar f_radius) : 
+   CDynamics3DShapeManager::SSphereResource::SSphereResource(btScalar f_radius) :
       Radius(f_radius),
       Shape(new btSphereShape(f_radius)) {}
 
    /****************************************/
    /****************************************/
 
-   std::vector<CDynamics3DShapeManager::SConvexHullResource> 
+   std::vector<CDynamics3DShapeManager::SConvexHullResource>
       CDynamics3DShapeManager::m_vecConvexHullResources;
 
    /****************************************/
    /****************************************/
 
    std::shared_ptr<btCollisionShape> CDynamics3DShapeManager::RequestConvexHull(const std::vector<btVector3>& vec_points) {
-      std::vector<SConvexHullResource>::iterator itConvexHullResource;      
+      std::vector<SConvexHullResource>::iterator itConvexHullResource;
       for(itConvexHullResource = std::begin(m_vecConvexHullResources);
           itConvexHullResource != std::end(m_vecConvexHullResources);
           ++itConvexHullResource) {
@@ -121,7 +121,7 @@ namespace argos {
       }
       /* If the resource doesn't exist, create a new one */
       if(itConvexHullResource == std::end(m_vecConvexHullResources)) {
-         itConvexHullResource = 
+         itConvexHullResource =
             m_vecConvexHullResources.emplace(itConvexHullResource, vec_points);
       }
       return std::static_pointer_cast<btCollisionShape>(itConvexHullResource->Shape);
@@ -142,4 +142,3 @@ namespace argos {
    /****************************************/
    /****************************************/
 }
-


### PR DESCRIPTION
- Makes ARGoS more self documenting by adding some bits about multiple physics
  engines, and optimization hints on how to get maxium performance for large swarms for:

  - Light sensor
  - Colored blob camera sensor
  - Multiple 2D physics engines 

- Also added more whitespace to plugin query strings to make it easier to
  maintain and format.

Original issue: #110 