### PR TITLE
Add MoveTo hook to QtOpenGLUserFunctions

### DIFF
--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.h
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.h
@@ -170,6 +170,16 @@ namespace argos {
       virtual void EntityDeselected(CEntity& c_entity) {}
 
       /**
+       * Called every time an entity is moved.
+       * @param c_entity The moved entity.
+       * @param c_old_pos The old position of the entity.
+       * @param c_new_pos The new position of the entity.
+       */
+      virtual void EntityMoved(CEntity& c_entity,
+                               const CVector3& c_old_pos,
+                               const CVector3& c_new_pos) {}
+
+      /**
        * Returns the currently selected entity, or NULL.
        */
       CEntity* GetSelectedEntity();

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.cpp
@@ -845,8 +845,10 @@ namespace argos {
             with the plane created before */
          CVector3 cNewPos;
          if(cMouseRay.Intersects(cXYPlane, cNewPos)) {
-            pcEntity->MoveTo(cNewPos,
-                             pcEntity->GetOriginAnchor().Orientation);
+            CVector3 cOldPos(pcEntity->GetOriginAnchor().Position);
+            if(pcEntity->MoveTo(cNewPos, pcEntity->GetOriginAnchor().Orientation)) {
+               m_cUserFunctions.EntityMoved(pcEntity->GetRootEntity(), cOldPos, cNewPos);
+            }
             /* Entity moved, redraw */
             update();
          }


### PR DESCRIPTION
This pull request adds a hook to the QtOpenGLUserFunctions class to enable executing code when an entity is moved.