### PR TITLE
Update indices after adding/removing an entity

### DIFF
--- a/src/plugins/simulator/media/directional_led_medium.cpp
+++ b/src/plugins/simulator/media/directional_led_medium.cpp
@@ -93,6 +93,7 @@ namespace argos {
 
    void CDirectionalLEDMedium::AddEntity(CDirectionalLEDEntity& c_entity) {
       m_pcDirectionalLEDEntityIndex->AddEntity(c_entity);
+      m_pcDirectionalLEDEntityIndex->Update();
    }
 
    /****************************************/
@@ -100,6 +101,7 @@ namespace argos {
 
    void CDirectionalLEDMedium::RemoveEntity(CDirectionalLEDEntity& c_entity) {
       m_pcDirectionalLEDEntityIndex->RemoveEntity(c_entity);
+      m_pcDirectionalLEDEntityIndex->Update();
    }
 
    /****************************************/

--- a/src/plugins/simulator/media/led_medium.cpp
+++ b/src/plugins/simulator/media/led_medium.cpp
@@ -99,6 +99,7 @@ namespace argos {
 
    void CLEDMedium::AddEntity(CLEDEntity& c_entity) {
       m_pcLEDEntityIndex->AddEntity(c_entity);
+      m_pcLEDEntityIndex->Update();
    }
 
    /****************************************/
@@ -106,6 +107,7 @@ namespace argos {
 
    void CLEDMedium::RemoveEntity(CLEDEntity& c_entity) {
       m_pcLEDEntityIndex->RemoveEntity(c_entity);
+      m_pcLEDEntityIndex->Update();
    }
 
    /****************************************/

--- a/src/plugins/simulator/media/rab_medium.cpp
+++ b/src/plugins/simulator/media/rab_medium.cpp
@@ -204,6 +204,7 @@ namespace argos {
          std::make_pair<ssize_t, CSet<CRABEquippedEntity*,SEntityComparator> >(
             c_entity.GetIndex(), CSet<CRABEquippedEntity*,SEntityComparator>()));
       m_pcRABEquippedEntityIndex->AddEntity(c_entity);
+      m_pcRABEquippedEntityIndex->Update();
    }
 
    /****************************************/
@@ -211,6 +212,7 @@ namespace argos {
 
    void CRABMedium::RemoveEntity(CRABEquippedEntity& c_entity) {
       m_pcRABEquippedEntityIndex->RemoveEntity(c_entity);
+      m_pcRABEquippedEntityIndex->Update();
       TRoutingTable::iterator it = m_tRoutingTable.find(c_entity.GetIndex());
       if(it != m_tRoutingTable.end())
          m_tRoutingTable.erase(it);

--- a/src/plugins/simulator/media/radio_medium.cpp
+++ b/src/plugins/simulator/media/radio_medium.cpp
@@ -94,6 +94,7 @@ namespace argos {
 
    void CRadioMedium::AddEntity(CRadioEntity& c_entity) {
       m_pcRadioEntityIndex->AddEntity(c_entity);
+      m_pcRadioEntityIndex->Update();
    }
 
    /****************************************/
@@ -101,6 +102,7 @@ namespace argos {
 
    void CRadioMedium::RemoveEntity(CRadioEntity& c_entity) {
       m_pcRadioEntityIndex->RemoveEntity(c_entity);
+      m_pcRadioEntityIndex->Update();
    }
 
    /****************************************/

--- a/src/plugins/simulator/media/tag_medium.cpp
+++ b/src/plugins/simulator/media/tag_medium.cpp
@@ -93,6 +93,7 @@ namespace argos {
 
    void CTagMedium::AddEntity(CTagEntity& c_entity) {
       m_pcTagEntityIndex->AddEntity(c_entity);
+      m_pcTagEntityIndex->Update();
    }
 
    /****************************************/
@@ -100,6 +101,7 @@ namespace argos {
 
    void CTagMedium::RemoveEntity(CTagEntity& c_entity) {
       m_pcTagEntityIndex->RemoveEntity(c_entity);
+      m_pcTagEntityIndex->Update();
    }
 
    /****************************************/


### PR DESCRIPTION
This patch forces the different types of media to stay up to date after an entity has been added or removed. The change creates overhead during initialization but as a result, guarantees that the media is always safe to access.