### PR TITLE
ARGoS docs for noise levels

### DIFF
--- a/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
@@ -94,9 +94,9 @@ namespace argos {
          m_cCameraPos += m_cOmnicamEntity.GetOffset();
          m_cOcclusionCheckRay.SetStart(m_cCameraPos);
       }
-      
+
    private:
-      
+
       CCI_ColoredBlobOmnidirectionalCameraSensor::TBlobList& m_tBlobs;
       COmnidirectionalCameraEquippedEntity& m_cOmnicamEntity;
       CEmbodiedEntity& m_cEmbodiedEntity;
@@ -291,9 +291,13 @@ namespace argos {
                    "    ...\n"
                    "  </controllers>\n\n"
 
-                   "It is possible to add uniform noise to the blobs, thus matching the\n"
+                   "It is possible to add noise to the detected blobs, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
-                   "\"noise_std_dev\".\n\n"
+                   "\"noise_std_dev\", which must be specified as a postive float in [0.0,1.0].\n"
+                   "Each timestep the camera is enabled, a vector of randomly generated noise\n"
+                   "{Gaussian(noise_std_dev), Uniform(0, 2*pi)} is added the reading for each\n"
+                   "detected blob.\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"

--- a/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
@@ -180,7 +180,9 @@ REGISTER_ACTUATOR(CDifferentialSteeringDefaultActuator,
                   "b = random bias from a Gaussian distribution\n"
                   "f = random factor from a Gaussian distribution\n"
                   "a = actual actuated value\n\n"
+
                   "a = f * (w + b)\n\n"
+
                   "You can configure the average and stddev of both the bias and the factor. This\n"
                   "can be done with the optional attributes: 'bias_avg', 'bias_stddev',\n"
                   "'factor_avg', and 'factor_stddev'. Bias attributes are expressed in m/s, while\n"

--- a/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
@@ -149,10 +149,13 @@ namespace argos {
 
                    "OPTIONAL XML CONFIGURATION\n\n"
 
-                   "It is possible to add uniform noise to the sensors, thus matching the\n"
+                   "It is possible to add uniform noise to the sensor, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
-                   "\"noise_level\", whose allowed range is in [-1,1] and is added to the calculated\n"
-                   "reading. The final sensor reading is always normalized in the [0-1] range.\n\n"
+                   "\"noise_level\", which must be specified as a postive float in [0.0,1.0].\n"
+                   "Each timestep, randomly generated noise from a uniform distribution\n"
+                   "[-noise_level, noise_level], will be added to the calculated reading. The final\n"
+                   "sensor reading is always normalized in the [0-1] range.\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"

--- a/src/plugins/robots/generic/simulator/light_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/light_default_sensor.cpp
@@ -221,9 +221,11 @@ namespace argos {
                    "    ...\n"
                    "  </controllers>\n\n"
 
-                   "It is possible to add uniform noise to the sensors, thus matching the\n"
+                   "It is possible to add uniform noise to the sensor, thus matching the\n"       
                    "characteristics of a real robot better. This can be done with the attribute\n"
-                   "\"noise_level\", whose allowed range is in [-1,1] and is added to the calculated\n"
+                   "\"noise_level\", which must be specified as a postive float in [0.0,1.0].\n"
+                   "Each timestep the sensor is enabled, randomly generated noise from a uniform\n"
+                   "distribution [-noise_level, noise_level], will be added to the calculated\n"
                    "reading. The final sensor reading is always normalized in the [0-1] range.\n\n"
 
                    "  <controllers>\n"

--- a/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
@@ -190,10 +190,12 @@ namespace argos {
                    "    ...\n"
                    "  </controllers>\n\n"
 
-                   "It is possible to add uniform noise to the sensors, thus matching the\n"
+                   "It is possible to add uniform noise to the sensor, thus matching the\n"
                    "characteristics of a real robot better. This can be done with the attribute\n"
-                   "\"noise_level\", whose allowed range is in [-1,1] and is added to the calculated\n"
-                   "reading. The final sensor reading is always normalized in the [0-1] range.\n\n"
+                   "\"noise_level\", which must be specified as a postive float in [0.0,1.0].\n"
+                   "Each timestep, randomly generated noise from a uniform distribution\n"
+                   "[-noise_level, noise_level], will be added to the calculated reading. The final\n"
+                   "sensor reading is always normalized in the [0-1] range.\n\n"
 
                    "  <controllers>\n"
                    "    ...\n"


### PR DESCRIPTION
ARGoS documentation for how to add noise for some sensors/actuators was
inconsistent. Specifically, it said that the range was [-1,1], but the code
explicitly disallows negative numbers.
