### PR TITLE
Add an option to hide the boundary walls in QtOpenGL.

### DIFF
--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_main_window.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_main_window.cpp
@@ -489,6 +489,10 @@ namespace argos {
       bool bInvertMouse;
       GetNodeAttributeOrDefault(t_tree, "invert_mouse", bInvertMouse, false);
       m_pcOpenGLWidget->SetInvertMouse(bInvertMouse);
+      /* Show boundary walls? */
+      bool bShowBoundary;
+      GetNodeAttributeOrDefault(t_tree, "show_boundary", bShowBoundary, true);
+      m_pcOpenGLWidget->SetShowBoundary(bShowBoundary);
       /* Set the window as the central widget */
       CQTOpenGLLayout* pcQTOpenGLLayout = new CQTOpenGLLayout();
       pcQTOpenGLLayout->addWidget(m_pcOpenGLWidget);

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.cpp
@@ -50,6 +50,7 @@ namespace argos {
       m_bInvertMouse(false),
       m_cSimulator(CSimulator::GetInstance()),
       m_cSpace(m_cSimulator.GetSpace()),
+      m_bShowBoundary(true),
       m_bUsingFloorTexture(false),
       m_pcFloorTexture(NULL),
       m_pcGroundTexture(NULL) {
@@ -724,45 +725,47 @@ namespace argos {
 #endif
       /* Disable the textures */
       glDisable(GL_TEXTURE_2D);
-      /* Draw walls */
-      glDisable(GL_CULL_FACE);
-      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-      glLineWidth(10.0f);
-      glColor3f(0.0f, 0.0f, 0.0f);
-      /* This part covers the top and bottom faces (parallel to XY) */
-      glBegin(GL_QUADS);
-      /* Top face */
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
-      glEnd();
-      /* This part covers the faces (South, East, North, West) */
-      glBegin(GL_QUADS);
-      /* South face */
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
-      /* East face */
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
-      /* North face */
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
-      /* West face */
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
-      glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
-      glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
-      glEnd();
-      glLineWidth(1.0f);
-      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-      glEnable(GL_CULL_FACE);
+      if(m_bShowBoundary) {
+         /* Draw walls */
+         glDisable(GL_CULL_FACE);
+         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+         glLineWidth(10.0f);
+         glColor3f(0.0f, 0.0f, 0.0f);
+         /* This part covers the top and bottom faces (parallel to XY) */
+         glBegin(GL_QUADS);
+         /* Top face */
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
+         glEnd();
+         /* This part covers the faces (South, East, North, West) */
+         glBegin(GL_QUADS);
+         /* South face */
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
+         /* East face */
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
+         /* North face */
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMinCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMinCorner.GetY(), cArenaMaxCorner.GetZ());
+         /* West face */
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
+         glVertex3f(cArenaMinCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMaxCorner.GetZ());
+         glVertex3f(cArenaMaxCorner.GetX(), cArenaMaxCorner.GetY(), cArenaMinCorner.GetZ());
+         glEnd();
+         glLineWidth(1.0f);
+         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+         glEnable(GL_CULL_FACE);
+      }
       /* Restore lighting */
       glEnable(GL_LIGHTING);
    }

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.h
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.h
@@ -229,8 +229,15 @@ namespace argos {
       /**
        * Sets whether the mouse should be inverted when moving.
        */
-      inline void SetInvertMouse(bool b_InvertMouse) {
-    	  m_bInvertMouse = b_InvertMouse;
+      inline void SetInvertMouse(bool b_invert_mouse) {
+         m_bInvertMouse = b_invert_mouse;
+      }
+
+      /**
+       * Sets whether the boundary walls should be rendered.
+       */
+      inline void SetShowBoundary(bool b_show_boundary) {
+         m_bShowBoundary = b_show_boundary;
       }
 
    signals:
@@ -371,6 +378,9 @@ namespace argos {
       CSimulator& m_cSimulator;
       /** Reference to the space state */
       CSpace& m_cSpace;
+
+      /** True if the boundary walls should be shown */
+      bool m_bShowBoundary;
 
       /** True if using a user-defined texture for the floor */
       bool m_bUsingFloorTexture;


### PR DESCRIPTION
This commit adds an optional XML attribute `show_boundary` to the configuration of QtOpenGL visualisation plugin. By default, this option is true and the black lines marking the boundaries of the simulation are drawn. Setting `show_boundary` to false disables this behavior.