### PR TITLE
Access to ARGoS threads in loop functions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -143,12 +143,12 @@ ARGoS sources under Eclipse
 To use Eclipse with the ARGoS sources, you must have the
 http://www.eclipse.org/cdt/[CDT] installed. Optionally, you can also
 install http://cmakeed.sourceforge.net/[CMakeEd] to modify the
-+CMakeLists.txt+ files comfortably within Eclipse.   
++CMakeLists.txt+ files comfortably within Eclipse.
 
 To configure the ARGoS sources for Eclipse, it is better to avoid
 compiling the code in a separate build directory (for more details, see
 http://www.vtk.org/Wiki/Eclipse_CDT4_Generator#Out-Of-Source_Builds[here]).
-Thus, execute CMake as follows:  
+Thus, execute CMake as follows:
 
  $ cd argos3
  $ cmake -G "Eclipse CDT4 - Unix Makefiles" src/

--- a/src/core/simulator/loop_functions.h
+++ b/src/core/simulator/loop_functions.h
@@ -16,6 +16,8 @@ namespace argos {
    class CEmbodiedEntity;
 }
 
+#include <functional>
+
 #include <argos3/core/utility/configuration/base_configurable_resource.h>
 #include <argos3/core/simulator/simulator.h>
 #include <argos3/core/simulator/space/space.h>
@@ -231,6 +233,35 @@ namespace argos {
        * @param c_entity A reference to the entity to remove.
        */
       virtual void RemoveEntity(CEntity& c_entity);
+
+
+     /**
+      * \brief Iterate over all controllable entities currently present in the
+      * arena (including those that are currently disabled) executing the
+      * specified callback on each.
+      *
+      * The specified callback can be executed in a multi-threaded context,
+      * depending on configuration (i.e. how many threads were specified in the
+      * input file) improving simulation efficiency by re-using ARGoS threads
+      * rather than the loop functions having to create/maintain its own thread
+      * pool(s). If multiple ARGoS threads are specified, the following
+      * operations CANNOT be safely performed on the entity passed to each
+      * callback:
+      *
+      * - Entity removal
+      * - Creating a new entity based on the current one
+      *
+      * Furthermore, iteration over controllable entities can be performed AT
+      * MOST twice in one timestep: one time in PreStep(), and one time in
+      * PostStep(). Mutiple iteration attempts in either function will cause a
+      * deadlock due to how iteration is implemented.
+      *
+      * @see PostStep()
+      * @see PreStep()
+      */
+      void IterateOverControllableEntities(const CSpace::TControllableEntityIterCBType& c_cb) const {
+        m_cSpace.IterateOverControllableEntities(c_cb);
+      }
 
    private:
 

--- a/src/core/simulator/space/space.cpp
+++ b/src/core/simulator/space/space.cpp
@@ -127,10 +127,35 @@ namespace argos {
       UpdateMedia();
       /* Call loop functions */
       m_cSimulator.GetLoopFunctions().PreStep();
+      /*
+       * If the loop functions did not use ARGoS threads during PreStep(), tell
+       * the waiting thread pool to continue.
+       */
+      if (!ControllableEntityIterationEnabled()) {
+        ControllableEntityIterationWaitAbort();
+      }
+      /*
+       * Reset callback to NULL to disable entity iteration for PostStep()
+       * unless enabled again by the loop functions.
+       */
+      m_cbControllableEntityIter = nullptr;
       /* Perform the 'sense+step' phase for controllable entities */
       UpdateControllableEntitiesSenseStep();
       /* Call loop functions */
       m_cSimulator.GetLoopFunctions().PostStep();
+
+      /*
+       * If the loop functions did not use ARGoS threads during PostStep(), tell
+       * the waiting thread pool to continue.
+       */
+      if (!ControllableEntityIterationEnabled()) {
+        ControllableEntityIterationWaitAbort();
+      }
+      /*
+       * Reset callback to NULL to disable entity iteration for next PreStep()
+       * unless enabled again by the loop functions.
+       */
+      m_cbControllableEntityIter = nullptr;
       /* Flush logs */
       LOG.Flush();
       LOGERR.Flush();

--- a/src/core/simulator/space/space_multi_thread_balance_length.cpp
+++ b/src/core/simulator/space/space_multi_thread_balance_length.cpp
@@ -18,6 +18,7 @@ namespace argos {
       pthread_mutex_t* StartActPhaseMutex;
       pthread_mutex_t* StartPhysicsPhaseMutex;
       pthread_mutex_t* StartMediaPhaseMutex;
+      pthread_mutex_t* StartEntityIterPhaseMutex;
       pthread_mutex_t* FetchTaskMutex;
    };
 
@@ -33,6 +34,7 @@ namespace argos {
       pthread_mutex_unlock(sData.StartActPhaseMutex);
       pthread_mutex_unlock(sData.StartPhysicsPhaseMutex);
       pthread_mutex_unlock(sData.StartMediaPhaseMutex);
+      pthread_mutex_unlock(sData.StartEntityIterPhaseMutex);
    }
 
    void* LaunchThreadBalanceLength(void* p_data) {
@@ -50,6 +52,7 @@ namespace argos {
       sCancelData.StartActPhaseMutex = &(psData->Space->m_tStartActPhaseMutex);
       sCancelData.StartPhysicsPhaseMutex = &(psData->Space->m_tStartPhysicsPhaseMutex);
       sCancelData.StartMediaPhaseMutex = &(psData->Space->m_tStartMediaPhaseMutex);
+      sCancelData.StartEntityIterPhaseMutex = &(psData->Space->m_tStartEntityIterPhaseMutex);
       sCancelData.FetchTaskMutex = &(psData->Space->m_tFetchTaskMutex);
       pthread_cleanup_push(CleanupThread, &sCancelData);
       psData->Space->SlaveThread();
@@ -71,6 +74,7 @@ namespace argos {
          (nErrors = pthread_mutex_init(&m_tStartActPhaseMutex, NULL)) ||
          (nErrors = pthread_mutex_init(&m_tStartPhysicsPhaseMutex, NULL)) ||
          (nErrors = pthread_mutex_init(&m_tStartMediaPhaseMutex, NULL)) ||
+         (nErrors = pthread_mutex_init(&m_tStartEntityIterPhaseMutex, NULL)) ||
          (nErrors = pthread_mutex_init(&m_tFetchTaskMutex, NULL))) {
          THROW_ARGOSEXCEPTION("Error creating thread mutexes " << ::strerror(nErrors));
       }
@@ -79,6 +83,7 @@ namespace argos {
          (nErrors = pthread_cond_init(&m_tStartActPhaseCond, NULL)) ||
          (nErrors = pthread_cond_init(&m_tStartPhysicsPhaseCond, NULL)) ||
          (nErrors = pthread_cond_init(&m_tStartMediaPhaseCond, NULL)) ||
+         (nErrors = pthread_cond_init(&m_tStartEntityIterPhaseCond, NULL)) ||
          (nErrors = pthread_cond_init(&m_tFetchTaskCond, NULL))) {
          THROW_ARGOSEXCEPTION("Error creating thread conditionals " << ::strerror(nErrors));
       }
@@ -87,6 +92,7 @@ namespace argos {
       m_unActPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
       m_unPhysicsPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
       m_unMediaPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
+      m_unEntityIterPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
       /* Start threads */
       StartThreads();
    }
@@ -126,11 +132,14 @@ namespace argos {
       pthread_mutex_destroy(&m_tStartActPhaseMutex);
       pthread_mutex_destroy(&m_tStartPhysicsPhaseMutex);
       pthread_mutex_destroy(&m_tStartMediaPhaseMutex);
+      pthread_mutex_destroy(&m_tStartEntityIterPhaseMutex);
       pthread_mutex_destroy(&m_tFetchTaskMutex);
+
       pthread_cond_destroy(&m_tStartSenseControlPhaseCond);
       pthread_cond_destroy(&m_tStartActPhaseCond);
       pthread_cond_destroy(&m_tStartPhysicsPhaseCond);
       pthread_cond_destroy(&m_tStartMediaPhaseCond);
+      pthread_cond_destroy(&m_tStartEntityIterPhaseCond);
       pthread_cond_destroy(&m_tFetchTaskCond);
 
       /* Destroy the base space */
@@ -146,6 +155,7 @@ namespace argos {
       m_unActPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
       m_unPhysicsPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
       m_unMediaPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
+      m_unEntityIterPhaseIdleCounter = CSimulator::GetInstance().GetNumThreads();
       /* Update the space */
       CSpace::Update();
    }
@@ -200,6 +210,18 @@ namespace argos {
    /****************************************/
    /****************************************/
 
+   void CSpaceMultiThreadBalanceLength::IterateOverControllableEntities(
+       const TControllableEntityIterCBType &c_cb) {
+     m_cbControllableEntityIter = c_cb;
+     /* Iterate over all robots in the swarm */
+     MAIN_START_PHASE(EntityIter);
+     MAIN_WAIT_FOR_END_OF(EntityIter);
+   } /* IterateOverControllableEntities() */
+
+
+   /****************************************/
+   /****************************************/
+
    void CSpaceMultiThreadBalanceLength::UpdateControllableEntitiesSenseStep() {
       /* Sense/control phase */
       MAIN_START_PHASE(SenseControl);
@@ -238,10 +260,10 @@ namespace argos {
    pthread_mutex_unlock(&m_tStart ## PHASE ## PhaseMutex);                                  \
    pthread_testcancel();
 
-#define THREAD_PERFORM_TASK(PHASE, TASKVEC, SNIPPET)                \
+#define THREAD_PERFORM_TASK(PHASE, TASKVEC, CONDITION, SNIPPET)     \
    while(1) {                                                       \
       pthread_mutex_lock(&m_tFetchTaskMutex);                       \
-      if(m_unTaskIndex < (TASKVEC).size()) {                        \
+      if((CONDITION) && m_unTaskIndex < (TASKVEC).size()) {         \
          unTaskIndex = m_unTaskIndex;                               \
          ++m_unTaskIndex;                                           \
          pthread_mutex_unlock(&m_tFetchTaskMutex);                  \
@@ -272,30 +294,48 @@ namespace argos {
          THREAD_PERFORM_TASK(
             Act,
             m_vecControllableEntities,
+            true,
             if(m_vecControllableEntities[unTaskIndex]->IsEnabled()) m_vecControllableEntities[unTaskIndex]->Act();
             );
          THREAD_WAIT_FOR_START_OF(Physics);
          THREAD_PERFORM_TASK(
             Physics,
             *m_ptPhysicsEngines,
+            true,
             (*m_ptPhysicsEngines)[unTaskIndex]->Update();
             );
          THREAD_WAIT_FOR_START_OF(Media);
          THREAD_PERFORM_TASK(
             Media,
             *m_ptMedia,
+            true,
             (*m_ptMedia)[unTaskIndex]->Update();
             );
+         /* loop functions PreStep() */
+         THREAD_WAIT_FOR_START_OF(EntityIter);
+         THREAD_PERFORM_TASK(
+             EntityIter,
+             m_vecControllableEntities,
+             ControllableEntityIterationEnabled(),
+             m_cbControllableEntityIter(m_vecControllableEntities[unTaskIndex]));
          THREAD_WAIT_FOR_START_OF(SenseControl);
          THREAD_PERFORM_TASK(
             SenseControl,
             m_vecControllableEntities,
+            true,
             if(m_vecControllableEntities[unTaskIndex]->IsEnabled()) {
                m_vecControllableEntities[unTaskIndex]->Sense();
                m_vecControllableEntities[unTaskIndex]->ControlStep();
             }
             );
-      }
+         /* loop functions PostStep() */
+         THREAD_WAIT_FOR_START_OF(EntityIter);
+         THREAD_PERFORM_TASK(
+             EntityIter,
+             m_vecControllableEntities,
+             ControllableEntityIterationEnabled(),
+             m_cbControllableEntityIter(m_vecControllableEntities[unTaskIndex]));
+      } /* while(1) */
    }
 
    /****************************************/

--- a/src/core/simulator/space/space_multi_thread_balance_length.h
+++ b/src/core/simulator/space/space_multi_thread_balance_length.h
@@ -34,6 +34,8 @@ namespace argos {
       virtual void UpdatePhysics();
       virtual void UpdateMedia();
       virtual void UpdateControllableEntitiesSenseStep();
+      virtual void IterateOverControllableEntities(
+          const TControllableEntityIterCBType& c_cb);
 
    private:
 
@@ -47,7 +49,7 @@ namespace argos {
       struct SThreadLaunchData {
          UInt32 ThreadId;
          CSpaceMultiThreadBalanceLength* Space;
-         
+
          SThreadLaunchData(UInt32 un_thread_id,
                            CSpaceMultiThreadBalanceLength* pc_space) :
             ThreadId(un_thread_id),
@@ -71,6 +73,8 @@ namespace argos {
       pthread_mutex_t m_tStartPhysicsPhaseMutex;
       /** Mutex for the start of the media phase */
       pthread_mutex_t m_tStartMediaPhaseMutex;
+      /** Mutex for the start of the robot iteration phase */
+      pthread_mutex_t m_tStartEntityIterPhaseMutex;
       /** Mutex to fetch a task from the dispatcher */
       pthread_mutex_t m_tFetchTaskMutex;
 
@@ -82,6 +86,8 @@ namespace argos {
       pthread_cond_t m_tStartPhysicsPhaseCond;
       /** Conditional for the start of the media phase */
       pthread_cond_t m_tStartMediaPhaseCond;
+      /** Conditional for the start of the robot iteration phase */
+      pthread_cond_t m_tStartEntityIterPhaseCond;
       /** Conditional controlling task fetching from the dispatcher */
       pthread_cond_t m_tFetchTaskCond;
 
@@ -93,6 +99,8 @@ namespace argos {
       UInt32 m_unPhysicsPhaseIdleCounter;
       /** How many threads are idle in the media phase */
       UInt32 m_unMediaPhaseIdleCounter;
+      /** How many threads are idle in the media phase */
+      UInt32 m_unEntityIterPhaseIdleCounter;
 
    };
 

--- a/src/core/simulator/space/space_no_threads.cpp
+++ b/src/core/simulator/space/space_no_threads.cpp
@@ -63,4 +63,14 @@ namespace argos {
    /****************************************/
    /****************************************/
 
+   void CSpaceNoThreads::IterateOverControllableEntities(
+       const TControllableEntityIterCBType& c_cb) {
+     for (size_t i = 0; i < m_vecControllableEntities.size(); ++i) {
+       c_cb(m_vecControllableEntities[i]);
+     } /* for(i..) */
+   } /* IterateOverControllableEntities() */
+
+   /****************************************/
+   /****************************************/
+
 }

--- a/src/core/simulator/space/space_no_threads.h
+++ b/src/core/simulator/space/space_no_threads.h
@@ -30,7 +30,8 @@ namespace argos {
       virtual void UpdatePhysics();
       virtual void UpdateMedia();
       virtual void UpdateControllableEntitiesSenseStep();
-
+      virtual void IterateOverControllableEntities(
+          const TControllableEntityIterCBType& c_cb);
    };
 
 }


### PR DESCRIPTION
- Uses std::function interface to allow `CLoopFunctions` derived classes to access ARGoS threads in 
  the `PreStep()` and `PostStep()` functions.

- Limited to 1 access/function call in each `PreStep()`, `PostStep()` in the loop
  functions. In theory you could add multiple accesses via a counter, but the
  phase-based approach in the code is not conducive to that without major
  modifications.

- Allowing such access increased simulation efficiency by 20-25% as compared with maintaining my 
  own thread pool in the loop functions for iterating through the swarm for metric collection, etc. in the 
  `PreStep()`/`PostStep()` functions.

- Also fix bug relating to entity removal when the "balance_quantity" thread
  method is used: the entities assigned to a particular thread were only being
  updated before the Act phase; if the loop functions `PreStep()`/`PostStep()`
  removed entities then the SenseControl phase would attempt to access memory
  that had already been freed and a segfault would result. Adding entity range
  assignment recalculation before ANY phase performing entity iteration solved
  this problem.

