### PR TITLE
Add the Lua script path to package.path.

### DIFF
--- a/src/core/wrappers/lua/lua_controller.cpp
+++ b/src/core/wrappers/lua/lua_controller.cpp
@@ -120,6 +120,19 @@ namespace argos {
       CreateLuaState();
       SensorReadingsToLuaState();
       ParametersToLuaState(t_tree);
+      /* Add the path of the script to package.path */
+      const std::string& strScriptPath =
+         str_script.substr(0, str_script.find_last_of('/'));
+      std::string strPackagePath;
+      strPackagePath += (strScriptPath + "/?.lua;");
+      strPackagePath += (strScriptPath + "/?/init.lua;");
+      lua_getglobal(m_ptLuaState, "package");
+      lua_getfield(m_ptLuaState, -1, "path");
+      strPackagePath += lua_tostring(m_ptLuaState, -1);
+      lua_pop(m_ptLuaState, 1);
+      lua_pushstring(m_ptLuaState, strPackagePath.c_str());
+      lua_setfield(m_ptLuaState, -2, "path");
+      lua_pop(m_ptLuaState, 1);
       /* Load script */
       if(!CLuaUtility::LoadScript(m_ptLuaState, str_script)) {
          m_bIsOK = false;


### PR DESCRIPTION
This commit makes it easier to work with more complex Lua controllers spread out over multiple files by adding the path of current Lua script to Lua's `package.path` variable. Consider the following controller declaration in a configuration file:
```xml
<lua_controller id="robot">
   <actuators/>
   <sensors/>
   <params script="path/to/controller.lua" />
</lua_controller>
```
where the contents of `controller.lua` is:
```lua
require('mymodule')
```
Without this commit, Lua will only search in the system directories and the current working directory for either `mymodule.lua` or `mymodule/init.lua`. This commit updates Lua's `package.path` variable so that the following locations are checked first: `path/to/mymodule.lua` and `path/to/mymodule/init.lua`.
