### PR TITLE
Enable rotating entities in the Qt-OpenGL visualization.

### DIFF
--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.h
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.h
@@ -180,6 +180,16 @@ namespace argos {
                                const CVector3& c_new_pos) {}
 
       /**
+       * Called every time an entity is rotated.
+       * @param c_entity The rotated entity.
+       * @param c_old_orientation The old orientation of the entity.
+       * @param c_new_orientation The new orientation of the entity.
+       */
+      virtual void EntityRotated(CEntity& c_entity,
+                                 const CQuaternion& c_old_orientation,
+                                 const CQuaternion& c_new_orientation) {}
+
+      /**
        * Returns the currently selected entity, or NULL.
        */
       CEntity* GetSelectedEntity();

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.h
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.h
@@ -342,6 +342,7 @@ namespace argos {
       virtual void mousePressEvent(QMouseEvent* pc_event);
       virtual void mouseReleaseEvent(QMouseEvent* pc_event);
       virtual void mouseMoveEvent(QMouseEvent* pc_event);
+      virtual void wheelEvent(QWheelEvent *pc_event);
       virtual void keyPressEvent(QKeyEvent* pc_event);
       virtual void keyReleaseEvent(QKeyEvent* pc_event);
       virtual void resizeEvent(QResizeEvent* pc_event);


### PR DESCRIPTION
This commit introduces the ability to rotate a selected entity while holding down the control key. If allowed by the physics engine, the entity is rotated around its z-axis by an amount proportional to the wheel movement (usually 1 increment = 15 degrees).

A new hook `QtOpenGLUserFunctions::EntityRotated` has been added which mirrors the functionality of `EntityMoved`.