### PR TITLE
bugfix(#14): dynamics3d init failure

### DIFF
--- a/src/plugins/robots/generic/control_interface/ci_camera_sensor.h
+++ b/src/plugins/robots/generic/control_interface/ci_camera_sensor.h
@@ -29,14 +29,14 @@ namespace argos {
          std::vector<CCI_CameraSensorAlgorithm*> Algorithms;
          typedef std::vector<SInterface> TVector;
       };
-      
+
    public:
-    
+
       /**
        * Constructor
        */
       CCI_CameraSensor() {}
-      
+
       /**
        * Destructor
        */
@@ -52,7 +52,7 @@ namespace argos {
 
 #ifdef ARGOS_WITH_LUA
       virtual void CreateLuaState(lua_State* pt_lua_state);
-      
+
       virtual void ReadingsToLuaState(lua_State* pt_lua_state);
 #endif
 
@@ -61,7 +61,7 @@ namespace argos {
       SInterface::TVector m_vecInterfaces;
 
    };
-   
+
 }
 
 #endif

--- a/src/plugins/robots/generic/control_interface/ci_camera_sensor_algorithms/ci_camera_sensor_directional_led_detector_algorithm.h
+++ b/src/plugins/robots/generic/control_interface/ci_camera_sensor_algorithms/ci_camera_sensor_directional_led_detector_algorithm.h
@@ -26,9 +26,9 @@ extern "C" {
 
 
 namespace argos {
-   
+
    class CCI_CameraSensorDirectionalLEDDetectorAlgorithm : virtual public CCI_CameraSensorAlgorithm {
-      
+
    public:
 
       struct SReading {
@@ -48,24 +48,24 @@ namespace argos {
       };
 
    public:
-      
+
       /**
        * Constructor
        */
       CCI_CameraSensorDirectionalLEDDetectorAlgorithm() {}
-      
+
       /**
        * Destructor
        */
       virtual ~CCI_CameraSensorDirectionalLEDDetectorAlgorithm() {}
-      
+
       const std::vector<SReading>& GetReadings() const {
          return m_vecReadings;
       }
-      
+
 #ifdef ARGOS_WITH_LUA
       virtual void CreateLuaState(lua_State* pt_lua_state);
-      
+
       virtual void ReadingsToLuaState(lua_State* pt_lua_state);
 
       virtual const std::string& GetId() {
@@ -77,9 +77,9 @@ namespace argos {
    protected:
 
       std::vector<SReading> m_vecReadings;
-      
+
    };
-   
+
 }
 
 #endif

--- a/src/plugins/robots/generic/simulator/camera_sensor_algorithms/camera_sensor_led_detector_algorithm.cpp
+++ b/src/plugins/robots/generic/simulator/camera_sensor_algorithms/camera_sensor_led_detector_algorithm.cpp
@@ -16,15 +16,15 @@
 namespace argos {
 
    /****************************************/
-   /****************************************/   
+   /****************************************/
 
    CCameraSensorLEDDetectorAlgorithm::CCameraSensorLEDDetectorAlgorithm() :
       m_bShowRays(false),
       m_pcLEDIndex(nullptr) {}
 
    /****************************************/
-   /****************************************/   
-   
+   /****************************************/
+
    void CCameraSensorLEDDetectorAlgorithm::Init(TConfigurationNode& t_tree) {
       try {
          /* Parent class init */
@@ -75,5 +75,5 @@ namespace argos {
                                     "returns the X and Y coordinates on the sensor",
                                     "This algorithm detects nearby LEDs seen by the camera and\n"
                                     "returns the X and Y coordinates on the sensor",
-                                    "Under development");  
+                                    "Under development");
 }

--- a/src/plugins/robots/prototype/simulator/dynamics3d_prototype_model.cpp
+++ b/src/plugins/robots/prototype/simulator/dynamics3d_prototype_model.cpp
@@ -117,7 +117,7 @@ namespace argos {
       /* Get the collision shape */
       std::shared_ptr<btCollisionShape> ptrBaseLinkShape = RequestShape(cBaseLink);
       /* Set up the base link body */
-      std::shared_ptr<CBase> ptrBase = 
+      std::shared_ptr<CBase> ptrBase =
          std::make_shared<CBase>(*this, &cBaseLink.GetAnchor(), ptrBaseLinkShape, CreateBodyData(cBaseLink));
       /* Add to collection */
       m_vecBodies.push_back(ptrBase);
@@ -148,7 +148,7 @@ namespace argos {
                continue;
             }
             /* Parent body must be a CLink, therefore no need to use dynamic_pointer_cast */
-            std::shared_ptr<CLink> ptrParentLinkBody = 
+            std::shared_ptr<CLink> ptrParentLinkBody =
                std::static_pointer_cast<CLink>(*itParentLinkBody);
             /* Get a reference to the child link */
             CPrototypeLinkEntity& cChildLink = cJoint.GetChildLink();
@@ -198,7 +198,7 @@ namespace argos {
             btQuaternion cParentToChildRotation = cParentOffsetTransform.inverse().getRotation() *
                cChildOffsetTransform.getRotation();
             */
-            btQuaternion cParentToChildRotation = cChildOffsetTransform.getRotation() * 
+            btQuaternion cParentToChildRotation = cChildOffsetTransform.getRotation() *
                cParentOffsetTransform.inverse().getRotation();
             /* Store joint configuration for reset */
             m_vecJoints.emplace_back(cJoint.GetType(),
@@ -508,4 +508,3 @@ namespace argos {
    /****************************************/
 
 }
-

--- a/src/plugins/robots/prototype/simulator/dynamics3d_prototype_model.h
+++ b/src/plugins/robots/prototype/simulator/dynamics3d_prototype_model.h
@@ -28,7 +28,7 @@ namespace argos {
       virtual ~CDynamics3DPrototypeModel() {}
 
       virtual void Reset();
-           
+
       virtual void UpdateEntityStatus();
 
       virtual void UpdateFromEntityStatus();

--- a/src/plugins/robots/prototype/simulator/prototype_link_entity.cpp
+++ b/src/plugins/robots/prototype/simulator/prototype_link_entity.cpp
@@ -32,7 +32,7 @@ namespace argos {
          std::string strLinkGeometry;
          GetNodeAttribute(t_tree, "geometry", strLinkGeometry);
          if(strLinkGeometry == "box") {
-            m_eGeometry = BOX; 
+            m_eGeometry = BOX;
             GetNodeAttribute(t_tree, "size", m_cExtents);
          } else if(strLinkGeometry == "cylinder") {
             m_eGeometry = CYLINDER;
@@ -55,7 +55,7 @@ namespace argos {
             /* Parse the points of the convex hull */
             GetNodeText(t_tree, strPoints);
             /* Remove any whitespace characters */
-            std::string::iterator itEraseBegin = 
+            std::string::iterator itEraseBegin =
                std::remove_if(std::begin(strPoints), std::end(strPoints), ::isspace);
             strPoints.erase(itEraseBegin, std::end(strPoints));
             /* Split into individual points */

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
@@ -49,6 +49,14 @@ namespace argos {
       for(tPluginIterator = tPluginIterator.begin(&t_tree);
           tPluginIterator != tPluginIterator.end();
           ++tPluginIterator) {
+        /*
+         * Boundary configuration handled in parent. <boundaries> is NOT a
+         * plugin, so we have to skip it when initializing, because it is
+         * nested under the engine just like the rest of the plugins.
+         */
+        if ("boundaries" == tPluginIterator->Value()) {
+          continue;
+        }
          CDynamics3DPlugin* pcPlugin = CFactory<CDynamics3DPlugin>::New(tPluginIterator->Value());
          pcPlugin->SetEngine(*this);
          pcPlugin->Init(*tPluginIterator);

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_model.h
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_model.h
@@ -42,7 +42,7 @@ namespace argos {
          using TVectorIterator = std::vector<std::shared_ptr<CAbstractBody> >::iterator;
 
          struct SData {
-            
+
             struct SDipole {
                /* Constructor */
                SDipole(const std::function<btVector3()>& fn_get_field,
@@ -165,7 +165,7 @@ namespace argos {
       CComposableEntity& m_cComposableEntity;
 
    };
-   
+
    /****************************************/
    /****************************************/
 

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_single_body_object_model.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_single_body_object_model.cpp
@@ -33,7 +33,7 @@ namespace argos {
                    c_position.GetZ(),
                   -c_position.GetY()));
       /* Move the body */
-      m_vecBodies[0]->GetTransform() = 
+      m_vecBodies[0]->GetTransform() =
          cTransform * m_vecBodies[0]->GetData().InverseCenterOfMassOffset;
       /* Synchronize with the entity in the space */
       UpdateEntityStatus();
@@ -80,7 +80,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics3DSingleBodyObjectModel::CBody::Reset() {
-      btRigidBody::btRigidBodyConstructionInfo cInfo(m_sData.Mass, 
+      btRigidBody::btRigidBodyConstructionInfo cInfo(m_sData.Mass,
                                                      nullptr,
                                                      &GetShape(),
                                                      m_sData.Inertia);
@@ -130,7 +130,7 @@ namespace argos {
 
    void CDynamics3DSingleBodyObjectModel::CBody::ApplyForce(const btVector3& c_force,
                                                             const btVector3& c_offset) {
-      m_cRigidBody.applyForce(c_force, c_offset);         
+      m_cRigidBody.applyForce(c_force, c_offset);
    }
 
    /****************************************/

--- a/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_box_model.cpp
+++ b/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_box_model.cpp
@@ -43,7 +43,7 @@ namespace argos {
                     GetEmbodiedEntity().GetOriginAnchor().Orientation);
       return m_cShape.Intersects(f_t_on_ray, c_ray);
    }
-   
+
    /****************************************/
    /****************************************/
 

--- a/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_box_model.h
+++ b/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_box_model.h
@@ -22,11 +22,11 @@ namespace argos {
    class CPointMass3DBoxModel : public CPointMass3DModel {
 
    public:
-      
+
       CPointMass3DBoxModel(CPointMass3DEngine& c_engine,
                            CBoxEntity& c_box);
       virtual ~CPointMass3DBoxModel() {}
-      
+
       virtual void UpdateFromEntityStatus() {}
       virtual void Step() {}
       virtual void UpdateEntityStatus() {}


### PR DESCRIPTION
- The <boundaries> tag was being treated as the name of a plugin, which it is
  not. Skipping it when looking for plugins to initialize fixes the problem.