### PR TITLE
docs(#15): Multiple dynamics3d engines

### DIFF
--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
@@ -334,6 +334,9 @@ namespace argos {
 
                            "The 'id' attribute is necessary and must be unique among the physics engines.\n\n"
 
+                           "Multiple physics engines of this type cannot be used, and defining '<boundaries>'\n"
+                           "as a child tag under the '<dynamics3d>' tree will result in an initialization error.\n\n"
+
                            "OPTIONAL XML CONFIGURATION\n\n"
 
                            "It is possible to change the default friction used in the simulation from\n"
@@ -376,7 +379,7 @@ namespace argos {
                            "    ...\n"
                            "  </physics_engines>\n\n",
 
-                           "Usable"
+                           "Usable (multiple engines not supported)"
       );
 
    /****************************************/


### PR DESCRIPTION
Update docs to be clear that multiple dynamics3d engines are not supported currently.