### PR TITLE
Enable/disable interface for simulated sensors

### DIFF
--- a/src/core/control_interface/ci_sensor.h
+++ b/src/core/control_interface/ci_sensor.h
@@ -70,6 +70,22 @@ namespace argos {
        */
       virtual void Destroy() {}
 
+      /**
+       * Enables updating of sensor information in the event loop. For some
+       * sensors, this must be called before using them, others are enabled by
+       * default.
+       */
+      virtual void Enable() { m_bEnabled = true; }
+
+      /**
+       * Disables updating of sensor information in the event loop.
+       */
+      virtual void Disable() { m_bEnabled = false; }
+
+      bool IsEnabled() const { return m_bEnabled; }
+      bool IsDisabled() const { return !m_bEnabled; }
+
+
 #ifdef ARGOS_WITH_LUA
       /**
        * Creates the Lua state for this sensor.
@@ -87,6 +103,10 @@ namespace argos {
       virtual void ReadingsToLuaState(lua_State* pt_lua_state) = 0;
 #endif
 
+   private:
+
+     /** Is this sensor currently enabled? */
+     bool m_bEnabled{false};
    };
 
 }

--- a/src/core/simulator/sensor.h
+++ b/src/core/simulator/sensor.h
@@ -43,10 +43,11 @@ namespace argos {
       virtual void SetRobot(CComposableEntity& c_entity) = 0;
 
       /**
-       * Updates the state of the entity associated to this sensor.
+       * Updates the state of the entity associated to this sensor, if the
+       * sensor is currently enabled. If it is disabled, then this function
+       * should do nothing.
        */
       virtual void Update() = 0;
-
    };
 
    /****************************************/

--- a/src/plugins/robots/e-puck/simulator/epuck_proximity_default_sensor.cpp
+++ b/src/plugins/robots/e-puck/simulator/epuck_proximity_default_sensor.cpp
@@ -37,6 +37,9 @@ namespace argos {
          m_pcControllableEntity = &(c_entity.GetComponent<CControllableEntity>("controller"));
          m_pcProximityEntity = &(c_entity.GetComponent<CProximitySensorEquippedEntity>("proximity_sensors"));
          m_pcProximityEntity->Enable();
+
+         /* sensor is enabled by default */
+         Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Can't set robot for the proximity default sensor", ex);
@@ -73,6 +76,10 @@ namespace argos {
    
    void CEPuckProximityDefaultSensor::Update()
    {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /* Ray used for scanning the environment for obstacles */
       CRay3 cScanningRay;
       CVector3 cRayStart, cRayEnd;
@@ -154,65 +161,11 @@ namespace argos {
                    "Danesh Tarapore [daneshtarapore@gmail.com]",
                    "1.0",
                    "The E-Puck proximity sensor.",
-                   "This sensor accesses a set of proximity sensors. The sensors all return a value\n"
-                   "between 0 and 1, where 0 means nothing within range and 1 means an external\n"
-                   "object is touching the sensor. Values between 0 and 1 depend on the distance of\n"
-                   "the occluding object, and are calculated as value=exp(-distance). In\n"
-                   "controllers, you must include the ci_proximity_sensor.h header.\n\n"
-                   "REQUIRED XML CONFIGURATION\n\n"
-                   "  <controllers>\n"
-                   "    ...\n"
-                   "    <my_controller ...>\n"
-                   "      ...\n"
-                   "      <sensors>\n"
-                   "        ...\n"
-                   "        <proximity implementation=\"default\" />\n"
-                   "        ...\n"
-                   "      </sensors>\n"
-                   "      ...\n"
-                   "    </my_controller>\n"
-                   "    ...\n"
-                   "  </controllers>\n\n"
-                   "OPTIONAL XML CONFIGURATION\n\n"
-                   "It is possible to draw the rays shot by the proximity sensor in the OpenGL\n"
-                   "visualization. This can be useful for sensor debugging but also to understand\n"
-                   "what's wrong in your controller. In OpenGL, the rays are drawn in cyan when\n"
-                   "they are not obstructed and in purple when they are. In case a ray is\n"
-                   "obstructed, a black dot is drawn where the intersection occurred.\n"
-                   "To turn this functionality on, add the attribute \"show_rays\" as in this\n"
-                   "example:\n\n"
-                   "  <controllers>\n"
-                   "    ...\n"
-                   "    <my_controller ...>\n"
-                   "      ...\n"
-                   "      <sensors>\n"
-                   "        ...\n"
-                   "        <proximity implementation=\"default\"\n"
-                   "                   show_rays=\"true\" />\n"
-                   "        ...\n"
-                   "      </sensors>\n"
-                   "      ...\n"
-                   "    </my_controller>\n"
-                   "    ...\n"
-                   "  </controllers>\n\n"
-                   "It is possible to add uniform noise to the sensors, thus matching the\n"
-                   "characteristics of a real robot better. This can be done with the attribute\n"
-                   "\"noise_level\", whose allowed range is in [-1,1] and is added to the calculated\n"
-                   "reading. The final sensor reading is always normalized in the [0-1] range.\n\n"
-                   "  <controllers>\n"
-                   "    ...\n"
-                   "    <my_controller ...>\n"
-                   "      ...\n"
-                   "      <sensors>\n"
-                   "        ...\n"
-                   "        <proximity implementation=\"default\"\n"
-                   "                   noise_level=\"0.1\" />\n"
-                   "        ...\n"
-                   "      </sensors>\n"
-                   "      ...\n"
-                   "    </my_controller>\n"
-                   "    ...\n"
-                   "  </controllers>\n\n",
+
+                   "This sensor accesses the epuck proximity sensor. For a complete description\n"
+                   "of its usage, refer to the ci_epuck_proximity_sensor.h interface. For the XML\n"
+                   "configuration, refer to the default proximity sensor.\n",
+
                    "Usable"
 		  );
 

--- a/src/plugins/robots/eye-bot/simulator/eyebot_light_rotzonly_sensor.cpp
+++ b/src/plugins/robots/eye-bot/simulator/eyebot_light_rotzonly_sensor.cpp
@@ -67,6 +67,9 @@ namespace argos {
          m_pcControllableEntity = &(c_entity.GetComponent<CControllableEntity>("controller"));
          m_pcLightEntity = &(c_entity.GetComponent<CLightSensorEquippedEntity>("light_sensors"));
          m_pcLightEntity->Enable();
+
+         /* sensor is enabled by default */
+         Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Can't set robot for the eye-bot light default sensor", ex);
@@ -102,6 +105,10 @@ namespace argos {
    /****************************************/
    
    void CEyeBotLightRotZOnlySensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /* Erase readings */
       for(size_t i = 0; i < m_tReadings.size(); ++i) {
          m_tReadings[i].Value = 0.0f;

--- a/src/plugins/robots/foot-bot/control_interface/ci_footbot_light_sensor.h
+++ b/src/plugins/robots/foot-bot/control_interface/ci_footbot_light_sensor.h
@@ -81,10 +81,6 @@ namespace argos {
       virtual void ReadingsToLuaState(lua_State* pt_lua_state);
 #endif
 
-     virtual void Enable() = 0;
-
-     virtual void Disable() = 0;
-
    protected:
 
       TReadings m_tReadings;

--- a/src/plugins/robots/foot-bot/simulator/footbot_base_ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_base_ground_rotzonly_sensor.cpp
@@ -58,6 +58,8 @@ namespace argos {
             m_pcRNG = CRandom::CreateRNG("argos");
          }
          m_tReadings.resize(8);
+         /* sensor is enabled by default */
+         Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in foot-bot rotzonly ground sensor", ex);
@@ -68,6 +70,10 @@ namespace argos {
    /****************************************/
 
    void CFootBotBaseGroundRotZOnlySensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /*
        * We make the assumption that the robot is rotated only wrt to Z
        */

--- a/src/plugins/robots/foot-bot/simulator/footbot_distance_scanner_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_distance_scanner_rotzonly_sensor.cpp
@@ -50,6 +50,9 @@ namespace argos {
             m_bAddNoise = true;
             m_pcRNG = CRandom::CreateRNG("argos");
          }
+
+         /* sensor is enabled by default */
+         Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in foot-bot distance scanner rot_z_only sensor.", ex);
@@ -70,6 +73,10 @@ namespace argos {
    /****************************************/
 
    void CFootBotDistanceScannerRotZOnlySensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /* Clear the maps */
       m_tReadingsMap.clear();
       m_tShortReadingsMap.clear();
@@ -334,6 +341,9 @@ namespace argos {
                    "the foot-bot is always parallel to the XY plane, i.e., it rotates only around\n"
                    "the Z axis. This implementation is faster than a 3D one and should be used\n"
                    "only when the assumption about the foot-bot rotation holds.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"
                    "    ...\n"

--- a/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
@@ -52,7 +52,6 @@ namespace argos {
    /****************************************/
 
    CFootBotLightRotZOnlySensor::CFootBotLightRotZOnlySensor() :
-      m_bEnabled(true),
       m_pcEmbodiedEntity(NULL),
       m_bShowRays(false),
       m_pcRNG(NULL),
@@ -93,6 +92,9 @@ namespace argos {
             m_pcRNG = CRandom::CreateRNG("argos");
          }
          m_tReadings.resize(m_pcLightEntity->GetNumSensors());
+
+         /* sensor is enabled by default */
+         Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in rot_z_only light sensor", ex);
@@ -103,7 +105,8 @@ namespace argos {
    /****************************************/
    
    void CFootBotLightRotZOnlySensor::Update() {
-      if (!m_bEnabled) {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
         return;
       }
       /* Erase readings */
@@ -226,20 +229,6 @@ namespace argos {
       for(UInt32 i = 0; i < GetReadings().size(); ++i) {
          m_tReadings[i].Value = 0.0f;
       }
-   }
-
-   /****************************************/
-   /****************************************/
-
-   void CFootBotLightRotZOnlySensor::Enable() {
-     m_bEnabled = true;
-   }
-
-   /****************************************/
-   /****************************************/
-
-   void CFootBotLightRotZOnlySensor::Disable() {
-     m_bEnabled = false;
    }
 
    /****************************************/

--- a/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.h
+++ b/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.h
@@ -40,10 +40,6 @@ namespace argos {
 
       virtual void Reset();
 
-     void Enable();
-
-     void Disable();
-
       /**
        * Returns true if the rays must be shown in the GUI.
        * @return true if the rays must be shown in the GUI.
@@ -62,8 +58,6 @@ namespace argos {
 
    protected:
 
-      /** Is this sensor currently enabled? */
-      bool             m_bEnabled;
       /** Reference to embodied entity associated to this sensor */
       CEmbodiedEntity* m_pcEmbodiedEntity;
 

--- a/src/plugins/robots/foot-bot/simulator/footbot_motor_ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_motor_ground_rotzonly_sensor.cpp
@@ -58,6 +58,9 @@ namespace argos {
             m_pcRNG = CRandom::CreateRNG("argos");
          }
          m_tReadings.resize(4);
+
+         /* sensor is enabled by default */
+         Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in foot-bot rotzonly ground sensor", ex);
@@ -68,6 +71,10 @@ namespace argos {
    /****************************************/
 
    void CFootBotMotorGroundRotZOnlySensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /*
        * We make the assumption that the robot is rotated only wrt to Z
        */

--- a/src/plugins/robots/foot-bot/simulator/footbot_turret_encoder_default_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_turret_encoder_default_sensor.cpp
@@ -20,14 +20,36 @@ namespace argos {
 
    void CFootBotTurretEncoderDefaultSensor::SetRobot(CComposableEntity& c_entity) {
       m_pcTurretEntity = &(c_entity.GetComponent<CFootBotTurretEntity>("turret"));
-      m_pcTurretEntity->Enable();
+
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
 
    void CFootBotTurretEncoderDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       m_cRotation = m_pcTurretEntity->GetRotation();
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CFootBotTurretEncoderDefaultSensor::Enable() {
+     m_pcTurretEntity->Enable();
+     CCI_Sensor::Enable();
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CFootBotTurretEncoderDefaultSensor::Disable() {
+     m_pcTurretEntity->Disable();
+     CCI_Sensor::Disable();
    }
 
    /****************************************/
@@ -48,7 +70,11 @@ namespace argos {
                    "This sensor accesses the foot-bot turret encoder. For a complete\n"
                    "description of its usage, refer to the ci_footbot_turret_encoder_sensor\n"
                    "file.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
+
                    "REQUIRED XML CONFIGURATION\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"

--- a/src/plugins/robots/foot-bot/simulator/footbot_turret_encoder_default_sensor.h
+++ b/src/plugins/robots/foot-bot/simulator/footbot_turret_encoder_default_sensor.h
@@ -36,6 +36,10 @@ namespace argos {
 
       virtual void Reset();
 
+      virtual void Enable();
+
+      virtual void Disable();
+
    private:
 
       CFootBotTurretEntity* m_pcTurretEntity;

--- a/src/plugins/robots/generic/control_interface/ci_colored_blob_omnidirectional_camera_sensor.h
+++ b/src/plugins/robots/generic/control_interface/ci_colored_blob_omnidirectional_camera_sensor.h
@@ -117,16 +117,6 @@ namespace argos {
        */
       const SReadings& GetReadings() const;
 
-      /**
-       * Enables image acquisition and processing.
-       */
-      virtual void Enable() = 0;
-
-      /**
-       * Disables image acquisition and processing.
-       */
-      virtual void Disable() = 0;
-
 #ifdef ARGOS_WITH_LUA
       virtual void CreateLuaState(lua_State* pt_lua_state);
 

--- a/src/plugins/robots/generic/control_interface/ci_colored_blob_perspective_camera_sensor.h
+++ b/src/plugins/robots/generic/control_interface/ci_colored_blob_perspective_camera_sensor.h
@@ -111,16 +111,6 @@ namespace argos {
        */
       const SReadings& GetReadings() const;
 
-      /**
-       * Enables image acquisition and processing.
-       */
-      virtual void Enable() = 0;
-
-      /**
-       * Disables image acquisition and processing.
-       */
-      virtual void Disable() = 0;
-
 #ifdef ARGOS_WITH_LUA
       virtual void CreateLuaState(lua_State* pt_lua_state);
 

--- a/src/plugins/robots/generic/simulator/battery_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/battery_default_sensor.cpp
@@ -58,12 +58,18 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in default battery sensor", ex);
       }
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
-   
+
    void CBatteryDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /* Save old charge value (used later for time left estimation) */
       Real fOldCharge = m_sReading.AvailableCharge;
       /* Update available charge as seen by the robot */
@@ -108,6 +114,8 @@ namespace argos {
                    "This sensor returns the current battery level of a robot. This sensor\n"
                    "can be used with any robot, since it accesses only the body component. In\n"
                    "controllers, you must include the ci_battery_sensor.h header.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"

--- a/src/plugins/robots/generic/simulator/camera_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/camera_default_sensor.cpp
@@ -118,13 +118,18 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Error initializing camera sensor", ex);
       }
-      Update();
+      /* sensor is disabled by default */
+      Disable();
    }
 
    /****************************************/
    /****************************************/
 
    void CCameraDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /* vector of controller rays */
       std::vector<std::pair<bool, CRay3> >& vecCheckedRays =
          m_pcControllableEntity->GetCheckedRays();
@@ -254,6 +259,9 @@ namespace argos {
                    "that algorithms can project a feature in the simulation on to the virtual\n"
                    "sensor and store its 2D pixel coordinates as a reading. The implementation\n"
                    "of algorithms that behave differently, however, is also possible.\n\n"
+
+                   "This sensor is disabled by default, and must be enabled before it can be\n"
+                   "used.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"

--- a/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
@@ -120,14 +120,12 @@ namespace argos {
    /****************************************/
 
    CColoredBlobOmnidirectionalCameraRotZOnlySensor::CColoredBlobOmnidirectionalCameraRotZOnlySensor() :
-      m_bEnabled(false),
       m_pcOmnicamEntity(NULL),
       m_pcControllableEntity(NULL),
       m_pcEmbodiedEntity(NULL),
       m_pcLEDIndex(NULL),
       m_pcEmbodiedIndex(NULL),
-      m_bShowRays(false) {
-   }
+      m_bShowRays(false) {}
 
    /****************************************/
    /****************************************/
@@ -175,29 +173,34 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Error initializing the colored blob omnidirectional camera rotzonly sensor", ex);
       }
+      /* sensor is disabled by default */
+      Disable();
    }
 
    /****************************************/
    /****************************************/
 
    void CColoredBlobOmnidirectionalCameraRotZOnlySensor::Update() {
-      if(m_bEnabled) {
-         /* Increase data counter */
-         ++m_sReadings.Counter;
-         /* Calculate range on the ground */
-         CVector3 cCameraPos = m_pcOmnicamEntity->GetOffset();
-         cCameraPos += m_pcEmbodiedEntity->GetOriginAnchor().Position;
-         Real fGroundHalfRange = cCameraPos.GetZ() * Tan(m_pcOmnicamEntity->GetAperture());
-         /* Prepare the operation */
-         m_pcOperation->Setup(fGroundHalfRange);
-         /* Go through LED entities in box range */
-         m_pcLEDIndex->ForEntitiesInBoxRange(
-            CVector3(cCameraPos.GetX(),
-                     cCameraPos.GetY(),
-                     cCameraPos.GetZ() * 0.5f),
-            CVector3(fGroundHalfRange, fGroundHalfRange, cCameraPos.GetZ() * 0.5f),
-            *m_pcOperation);
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
       }
+
+      /* Increase data counter */
+      ++m_sReadings.Counter;
+      /* Calculate range on the ground */
+      CVector3 cCameraPos = m_pcOmnicamEntity->GetOffset();
+      cCameraPos += m_pcEmbodiedEntity->GetOriginAnchor().Position;
+      Real fGroundHalfRange = cCameraPos.GetZ() * Tan(m_pcOmnicamEntity->GetAperture());
+      /* Prepare the operation */
+      m_pcOperation->Setup(fGroundHalfRange);
+      /* Go through LED entities in box range */
+      m_pcLEDIndex->ForEntitiesInBoxRange(
+         CVector3(cCameraPos.GetX(),
+                  cCameraPos.GetY(),
+                  cCameraPos.GetZ() * 0.5f),
+         CVector3(fGroundHalfRange, fGroundHalfRange, cCameraPos.GetZ() * 0.5f),
+         *m_pcOperation);
    }
 
    /****************************************/
@@ -220,7 +223,7 @@ namespace argos {
 
    void CColoredBlobOmnidirectionalCameraRotZOnlySensor::Enable() {
       m_pcOmnicamEntity->Enable();
-      m_bEnabled = true;
+      CCI_Sensor::Enable();
    }
 
    /****************************************/
@@ -228,7 +231,7 @@ namespace argos {
 
    void CColoredBlobOmnidirectionalCameraRotZOnlySensor::Disable() {
       m_pcOmnicamEntity->Disable();
-      m_bEnabled = false;
+      CCI_Sensor::Disable();
    }
 
    /****************************************/
@@ -244,6 +247,9 @@ namespace argos {
                    "sensor returns a list of blobs, each defined by a color and a position with\n"
                    "respect to the robot reference point on the ground. In controllers, you must\n"
                    "include the ci_colored_blob_omnidirectional_camera_sensor.h header.\n\n"
+
+                   "This sensor is disabled by default, and must be enabled before it can be\n"
+                   "used.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
 

--- a/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.h
+++ b/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.h
@@ -56,8 +56,6 @@ namespace argos {
       }
 
    protected:
-
-      bool                                     m_bEnabled;
       COmnidirectionalCameraEquippedEntity*    m_pcOmnicamEntity;
       CControllableEntity*                     m_pcControllableEntity;
       CEmbodiedEntity*                         m_pcEmbodiedEntity;

--- a/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.cpp
@@ -139,14 +139,12 @@ namespace argos {
    /****************************************/
 
    CColoredBlobPerspectiveCameraDefaultSensor::CColoredBlobPerspectiveCameraDefaultSensor() :
-      m_bEnabled(false),
       m_pcCamEntity(NULL),
       m_pcControllableEntity(NULL),
       m_pcEmbodiedEntity(NULL),
       m_pcLEDIndex(NULL),
       m_pcEmbodiedIndex(NULL),
-      m_bShowRays(false) {
-   }
+      m_bShowRays(false) {}
 
    /****************************************/
    /****************************************/
@@ -194,35 +192,39 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Error initializing the colored blob perspective camera default sensor", ex);
       }
+      /* sensor is disabled by default */
+      Disable();
    }
 
    /****************************************/
    /****************************************/
 
    void CColoredBlobPerspectiveCameraDefaultSensor::Update() {
-      if(m_bEnabled) {
-         /* Increase data counter */
-         ++m_sReadings.Counter;
-         /* Prepare the operation */
-         m_pcOperation->Setup();
-         /* Calculate the sensing box */
-         Real fHalfRange  = m_pcCamEntity->GetRange() * 0.5f;
-         Real fHalfSide   = fHalfRange * Tan(m_pcCamEntity->GetAperture());
-         /* Box center */
-         CVector3 cCenter(fHalfRange, 0.0f, 0.0f);
-         cCenter.Rotate(m_pcCamEntity->GetAnchor().Orientation);
-         cCenter += m_pcCamEntity->GetAnchor().Position;
-         /* Box half size */
-         CVector3 cCorner(fHalfRange, fHalfSide, fHalfSide);
-         cCorner.Rotate(m_pcCamEntity->GetAnchor().Orientation);
-         CVector3 cHalfSize(
-            Abs(cCorner.GetX()),
-            Abs(cCorner.GetY()),
-            Abs(cCorner.GetZ()));
-         /* Go through LED entities in box range */
-         m_pcLEDIndex->ForEntitiesInBoxRange(
-            cCenter, cHalfSize, *m_pcOperation);
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
       }
+      /* Increase data counter */
+      ++m_sReadings.Counter;
+      /* Prepare the operation */
+      m_pcOperation->Setup();
+      /* Calculate the sensing box */
+      Real fHalfRange  = m_pcCamEntity->GetRange() * 0.5f;
+      Real fHalfSide   = fHalfRange * Tan(m_pcCamEntity->GetAperture());
+      /* Box center */
+      CVector3 cCenter(fHalfRange, 0.0f, 0.0f);
+      cCenter.Rotate(m_pcCamEntity->GetAnchor().Orientation);
+      cCenter += m_pcCamEntity->GetAnchor().Position;
+      /* Box half size */
+      CVector3 cCorner(fHalfRange, fHalfSide, fHalfSide);
+      cCorner.Rotate(m_pcCamEntity->GetAnchor().Orientation);
+      CVector3 cHalfSize(
+         Abs(cCorner.GetX()),
+         Abs(cCorner.GetY()),
+         Abs(cCorner.GetZ()));
+      /* Go through LED entities in box range */
+      m_pcLEDIndex->ForEntitiesInBoxRange(
+         cCenter, cHalfSize, *m_pcOperation);
    }
 
    /****************************************/
@@ -245,7 +247,8 @@ namespace argos {
 
    void CColoredBlobPerspectiveCameraDefaultSensor::Enable() {
       m_pcCamEntity->Enable();
-      m_bEnabled = true;
+      CCI_Sensor::Enable();
+
    }
 
    /****************************************/
@@ -253,7 +256,8 @@ namespace argos {
 
    void CColoredBlobPerspectiveCameraDefaultSensor::Disable() {
       m_pcCamEntity->Disable();
-      m_bEnabled = false;
+      CCI_Sensor::Disable();
+
    }
 
    /****************************************/
@@ -269,6 +273,9 @@ namespace argos {
                    "sensor returns a list of blobs, each defined by a color and a position with\n"
                    "respect to the robot reference point on the ground. In controllers, you must\n"
                    "include the ci_colored_blob_perspective_camera_sensor.h header.\n\n"
+
+                   "This sensor is disabled by default, and must be enabled before it can be\n"
+                   "used.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
 

--- a/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.h
+++ b/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.h
@@ -36,9 +36,9 @@ namespace argos {
       virtual void Destroy();
 
       virtual void Enable();
-      
+
       virtual void Disable();
-			
+
       /**
        * Returns true if the rays must be shown in the GUI.
        * @return true if the rays must be shown in the GUI.
@@ -57,7 +57,6 @@ namespace argos {
 
    protected:
 
-      bool                                 m_bEnabled;
       CPerspectiveCameraEquippedEntity*    m_pcCamEntity;
       CControllableEntity*                 m_pcControllableEntity;
       CEmbodiedEntity*                     m_pcEmbodiedEntity;

--- a/src/plugins/robots/generic/simulator/differential_steering_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/differential_steering_default_sensor.cpp
@@ -57,12 +57,18 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in default differential steering sensor", ex);
       }
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
    
    void CDifferentialSteeringDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       m_sReading.VelocityLeftWheel = m_pfWheelVelocities[0] * 100.0f;
       m_sReading.VelocityRightWheel = m_pfWheelVelocities[1] * 100.0f;
       m_sReading.CoveredDistanceLeftWheel = m_sReading.VelocityLeftWheel * CPhysicsEngine::GetSimulationClockTick();
@@ -97,6 +103,8 @@ namespace argos {
                    "This sensor returns the current position and orientation of a robot. This sensor\n"
                    "can be used with any robot, since it accesses only the body component. In\n"
                    "controllers, you must include the ci_differential_steering_sensor.h header.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
 

--- a/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
@@ -62,12 +62,18 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in rotzonly ground sensor", ex);
       }
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
 
    void CGroundRotZOnlySensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /*
        * We make the assumption that the robot is rotated only wrt to Z
        */
@@ -131,6 +137,8 @@ namespace argos {
                    "of ground sensor, readings can either take 0 or 1 as value (bw sensors) or a\n"
                    "value in between (grayscale sensors). In controllers, you must include the\n"
                    "ci_ground_sensor.h header.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"

--- a/src/plugins/robots/generic/simulator/light_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/light_default_sensor.cpp
@@ -66,12 +66,18 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in default light sensor", ex);
       }
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
    
    void CLightDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /* Erase readings */
       for(size_t i = 0; i < m_tReadings.size(); ++i)  m_tReadings[i] = 0.0f;
       /* Ray used for scanning the environment for obstacles */
@@ -181,6 +187,8 @@ namespace argos {
                    "reading is calculated as the sum of the individual readings due to each light.\n"
                    "In other words, light wave interference is not taken into account. In\n"
                    "controllers, you must include the ci_light_sensor.h header.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"

--- a/src/plugins/robots/generic/simulator/positioning_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/positioning_default_sensor.cpp
@@ -45,6 +45,8 @@ namespace argos {
             m_bAddNoise = true;
             m_pcRNG = CRandom::CreateRNG("argos");
          }
+         /* sensor is enabled by default */
+         Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in default positioning sensor", ex);
@@ -55,6 +57,10 @@ namespace argos {
    /****************************************/
    
    void CPositioningDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       m_sReading.Position = m_pcEmbodiedEntity->GetOriginAnchor().Position;
       if(m_bAddNoise) {
          m_sReading.Position += CVector3(m_pcRNG->Uniform(m_cPosNoiseRange),
@@ -92,6 +98,8 @@ namespace argos {
                    "This sensor returns the current position and orientation of a robot. This sensor\n"
                    "can be used with any robot, since it accesses only the body component. In\n"
                    "controllers, you must include the ci_positioning_sensor.h header.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"

--- a/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
@@ -67,12 +67,18 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Initialization error in default proximity sensor", ex);
       }
+      /* This sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
-   
+
    void CProximityDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /* Ray used for scanning the environment for obstacles */
       CRay3 cScanningRay;
       CVector3 cRayStart, cRayEnd;
@@ -148,6 +154,8 @@ namespace argos {
                    "object is touching the sensor. Values between 0 and 1 depend on the distance of\n"
                    "the occluding object, and are calculated as value=exp(-distance). In\n"
                    "controllers, you must include the ci_proximity_sensor.h header.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
 

--- a/src/plugins/robots/generic/simulator/radios_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/radios_default_sensor.cpp
@@ -38,6 +38,9 @@ namespace argos {
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Can't set robot for the radios default sensor", ex);
       }
+
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
@@ -59,6 +62,10 @@ namespace argos {
    /****************************************/
 
    void CRadiosDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       for(size_t i = 0; i < m_pcRadioEquippedEntity->GetInstances().size(); ++i) {
          CRadioEntity& cRadio = m_pcRadioEquippedEntity->GetRadio(i);
          /* Clear data in the interface */
@@ -100,6 +107,8 @@ namespace argos {
                    "implementation is very basic and any concepts such as throughput, addressing,\n"
                    "or formatting of a message's contents is beyond the scope of this sensor's\n"
                    "implementation\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
 

--- a/src/plugins/robots/generic/simulator/radios_default_sensor.h
+++ b/src/plugins/robots/generic/simulator/radios_default_sensor.h
@@ -53,8 +53,8 @@ namespace argos {
    protected:
 
       CRadioEquippedEntity* m_pcRadioEquippedEntity;
-      CControllableEntity* m_pcControllableEntity;
-      bool m_bShowRays;
+      CControllableEntity*  m_pcControllableEntity;
+      bool                  m_bShowRays;
 
    };
 }

--- a/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.cpp
@@ -61,18 +61,22 @@ namespace argos {
          m_pcRangeAndBearingMedium = &(CSimulator::GetInstance().GetMedium<CRABMedium>(strMedium));
          /* Assign RAB entity to the medium */
          m_pcRangeAndBearingEquippedEntity->SetMedium(*m_pcRangeAndBearingMedium);
-         /* Enable the RAB equipped entity */
-         m_pcRangeAndBearingEquippedEntity->Enable();
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Error initializing the range and bearing medium sensor", ex);
       }
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
 
    void CRangeAndBearingMediumSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       /** TODO: there's a more efficient way to implement this */
       /* Delete old readings */
       m_tReadings.clear();
@@ -149,6 +153,22 @@ namespace argos {
       m_tReadings.clear();
    }
 
+
+   /****************************************/
+   /****************************************/
+   void CRangeAndBearingMediumSensor::Enable() {
+     m_pcRangeAndBearingEquippedEntity->Enable();
+     CCI_Sensor::Enable();
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CRangeAndBearingMediumSensor::Disable() {
+     m_pcRangeAndBearingEquippedEntity->Disable();
+     CCI_Sensor::Disable();
+   }
+
    /****************************************/
    /****************************************/
 
@@ -175,6 +195,8 @@ namespace argos {
                    "range-and-bearing actuator.\n"
                    "To use this sensor, in controllers you must include the\n"
                    "ci_range_and_bearing_sensor.h header.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
 
                    "REQUIRED XML CONFIGURATION\n\n"
                    "  <controllers>\n"

--- a/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.h
+++ b/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.h
@@ -31,11 +31,20 @@ namespace argos {
 
       CRangeAndBearingMediumSensor();
       virtual ~CRangeAndBearingMediumSensor() {}
+
       virtual void SetRobot(CComposableEntity& c_entity);
+
       virtual void Init(TConfigurationNode& t_tree);
+
       virtual void Update();
+
       virtual void Reset();
+
       virtual void Destroy();
+
+      virtual void Enable();
+
+      virtual void Disable();
 
       /**
        * Returns true if the rays must be shown in the GUI.

--- a/src/plugins/robots/prototype/simulator/prototype_joints_default_sensor.cpp
+++ b/src/plugins/robots/prototype/simulator/prototype_joints_default_sensor.cpp
@@ -12,8 +12,7 @@ namespace argos {
    /****************************************/
 
    CPrototypeJointsDefaultSensor::CPrototypeJointsDefaultSensor() :
-      m_pcJointEquippedEntity(nullptr) {
-   }
+      m_pcJointEquippedEntity(nullptr) {}
 
    /****************************************/
    /****************************************/
@@ -59,12 +58,18 @@ namespace argos {
          /* add joint actuators to the base class */
          m_vecSensors.push_back(&s_sensor);
       }
+      /* sensor is enabled by default */
+      Enable();
    }
 
    /****************************************/
    /****************************************/
 
    void CPrototypeJointsDefaultSensor::Update() {
+      /* sensor is disabled--nothing to do */
+      if (IsDisabled()) {
+        return;
+      }
       for(SSimulatedSensor& s_sensor : m_vecSimulatedSensors) {
          s_sensor.Value = s_sensor.Instance.Value;
       }
@@ -90,7 +95,12 @@ namespace argos {
                    "This sensor is used to monitor the joints inside a prototype entity. To monitor\n"
                    "a joint, add a joint child node to the joints node. Each child node has two\n"
                    "required attributes.\n\n"
+
+                   "This sensor is enabled by default.\n\n"
+
+
                    "REQUIRED XML CONFIGURATION\n\n"
+
                    "  <controllers>\n"
                    "    ...\n"
                    "    <my_controller ...>\n"


### PR DESCRIPTION
- All sensors have a common enable/disable interface, and the documentation
  generated for each via "argos3 -q <sensor>" has also been updated to say which
  sensors are enabled by default, and which need to be enabled before use.

- This replaces the previous semi-hack with the footbot light sensor, and now treats all simulated sensors the same. 