### PR TITLE
RFC initial attempt to improve error handling with Lua.

### DIFF
--- a/src/core/wrappers/lua/lua_controller.cpp
+++ b/src/core/wrappers/lua/lua_controller.cpp
@@ -43,7 +43,7 @@ namespace argos {
          if(strScriptFileName != "") {
             SetLuaScript(strScriptFileName, t_tree);
             if(! m_bIsOK) {
-               THROW_ARGOSEXCEPTION("Error loading Lua script \"" << strScriptFileName << "\": " << lua_tostring(m_ptLuaState, -1));
+               THROW_ARGOSEXCEPTION("Error setting Lua script");
             }
          }
          else {

--- a/src/core/wrappers/lua/lua_utility.cpp
+++ b/src/core/wrappers/lua/lua_utility.cpp
@@ -181,9 +181,15 @@ namespace argos {
    bool CLuaUtility::LoadScript(lua_State* pt_state,
                                 const std::string& str_filename) {
       if(luaL_loadfile(pt_state, str_filename.c_str())) {
+         LOGERR << "[FATAL] Error loading \"" << str_filename
+                << "\"" << std::endl;
          return false;
       }
       if(lua_pcall(pt_state, 0, 0, 0)) {
+         LOGERR << "[FATAL] Error executing \"" << str_filename
+                << "\"" << std::endl;
+         LOGERR << "[FATAL] " << lua_tostring(pt_state, -1)
+                << std::endl;
          return false;
       }
       return true;
@@ -196,6 +202,10 @@ namespace argos {
                                      const std::string& str_function) {
       lua_getglobal(pt_state, str_function.c_str());
       if(lua_pcall(pt_state, 0, 0, 0)) {
+         LOGERR << "[FATAL] Error calling \"" << str_function
+                << "\"" << std::endl;
+         LOGERR << "[FATAL] " << lua_tostring(pt_state, -1)
+                << std::endl;
          return false;
       }
       return true;


### PR DESCRIPTION
The error handling in CLuaController and CLuaUtility is a mixture of returning booleans, raising exceptions, and setting flags. This is an absolute mess and needs to be improved. This initial commit fixes one of the worst issues by reporting errors from Lua error during executing step/reset etc. Previously these errors were unreported by the simulator resulting in zombie robots.