### PR TITLE
Modernize auto and nullptr

### DIFF
--- a/src/core/control_interface/ci_controller.cpp
+++ b/src/core/control_interface/ci_controller.cpp
@@ -13,7 +13,7 @@ namespace argos {
 
    CCI_Controller::~CCI_Controller() {
       /* Delete actuators*/
-      for(CCI_Actuator::TMap::iterator itActuators = m_mapActuators.begin();
+      for(auto itActuators = m_mapActuators.begin();
           itActuators != m_mapActuators.end();
           ++itActuators) {
          delete itActuators->second;
@@ -21,7 +21,7 @@ namespace argos {
       m_mapActuators.clear();
 
       /* Delete sensors */
-      for(CCI_Sensor::TMap::iterator itSensors = m_mapSensors.begin();
+      for(auto itSensors = m_mapSensors.begin();
           itSensors != m_mapSensors.end();
           ++itSensors) {
          delete itSensors->second;
@@ -33,7 +33,7 @@ namespace argos {
    /****************************************/
 
    bool CCI_Controller::HasActuator(const std::string& str_actuator_type) const {
-      CCI_Actuator::TMap::const_iterator it = m_mapActuators.find(str_actuator_type);
+      auto it = m_mapActuators.find(str_actuator_type);
       return (it != m_mapActuators.end());
    }
 
@@ -41,7 +41,7 @@ namespace argos {
    /****************************************/
 
    bool CCI_Controller::HasSensor(const std::string& str_sensor_type) const {
-      CCI_Sensor::TMap::const_iterator it = m_mapSensors.find(str_sensor_type);
+      auto it = m_mapSensors.find(str_sensor_type);
       return (it != m_mapSensors.end());
    }
 

--- a/src/core/simulator/argos_command_line_arg_parser.cpp
+++ b/src/core/simulator/argos_command_line_arg_parser.cpp
@@ -14,8 +14,8 @@ namespace argos {
 
    CARGoSCommandLineArgParser::CARGoSCommandLineArgParser() :
       m_eAction(ACTION_UNKNOWN),
-      m_pcInitLogStream(NULL),
-      m_pcInitLogErrStream(NULL) {
+      m_pcInitLogStream(nullptr),
+      m_pcInitLogErrStream(nullptr) {
       AddFlag(
          'h',
          "help",

--- a/src/core/simulator/entity/composable_entity.cpp
+++ b/src/core/simulator/entity/composable_entity.cpp
@@ -27,7 +27,7 @@ namespace argos {
    /****************************************/
 
    void CComposableEntity::Reset() {
-      for(CEntity::TMultiMap::iterator it = m_mapComponents.begin();
+      for(auto it = m_mapComponents.begin();
           it != m_mapComponents.end();
           ++it) {
          it->second->Reset();
@@ -46,7 +46,7 @@ namespace argos {
 
    void CComposableEntity::SetEnabled(bool b_enabled) {
       CEntity::SetEnabled(b_enabled);
-      for(CEntity::TMultiMap::iterator it = m_mapComponents.begin();
+      for(auto it = m_mapComponents.begin();
           it != m_mapComponents.end();
           ++it) {
          it->second->SetEnabled(b_enabled);
@@ -57,7 +57,7 @@ namespace argos {
    /****************************************/
 
    void CComposableEntity::UpdateComponents() {
-      for(CEntity::TMultiMap::iterator it = m_mapComponents.begin();
+      for(auto it = m_mapComponents.begin();
           it != m_mapComponents.end();
           ++it) {
          if(it->second->IsEnabled()) {
@@ -82,7 +82,7 @@ namespace argos {
 
    CEntity& CComposableEntity::RemoveComponent(const std::string& str_component) {
       try {
-         CEntity::TMultiMap::iterator it = FindComponent(str_component);
+         auto it = FindComponent(str_component);
          if(it == m_mapComponents.end()) {
             THROW_ARGOSEXCEPTION("Element \"" << str_component << "\" not found in the component map.");
          }
@@ -114,7 +114,7 @@ namespace argos {
          if(unFirstSeparatorIdx == std::string::npos) strFrontIdentifier = str_path;
          else strFrontIdentifier = str_path.substr(0, unFirstSeparatorIdx);
          /* Try to find the relevant component in this context */
-         CEntity::TMultiMap::iterator itComponent = FindComponent(strFrontIdentifier);
+         auto itComponent = FindComponent(strFrontIdentifier);
          if(itComponent != m_mapComponents.end()) {
             if(unFirstSeparatorIdx == std::string::npos) {
                /* Path separator not found, found component in the current context is the one we want */
@@ -122,8 +122,8 @@ namespace argos {
             }
             /* Path separator found, try to cast the found component to a composable entity */
             else {
-               CComposableEntity* pcComposableEntity = dynamic_cast<CComposableEntity*>(itComponent->second);
-               if(pcComposableEntity != NULL) {
+               auto* pcComposableEntity = dynamic_cast<CComposableEntity*>(itComponent->second);
+               if(pcComposableEntity != nullptr) {
                   /* Dynamic cast of component to composable entity was successful, re-execute this function in the new context */
                   return pcComposableEntity->GetComponent(str_path.substr(unFirstSeparatorIdx + 1, std::string::npos));
                }
@@ -154,7 +154,7 @@ namespace argos {
       if(unFirstSeparatorIdx == std::string::npos) strFrontIdentifier = str_path;
       else strFrontIdentifier = str_path.substr(0, unFirstSeparatorIdx);
       /* Try to find the relevant component in this context */
-      CEntity::TMultiMap::iterator itComponent = FindComponent(strFrontIdentifier);
+      auto itComponent = FindComponent(strFrontIdentifier);
       if(itComponent != m_mapComponents.end()) {
          if(unFirstSeparatorIdx == std::string::npos) {
             /* Path separator not found, found component in the current context is the one we want */
@@ -162,8 +162,8 @@ namespace argos {
          }
          else {
             /* Path separator found, try to cast the found component to a composable entity */
-            CComposableEntity* pcComposableEntity = dynamic_cast<CComposableEntity*>(itComponent->second);
-            if(pcComposableEntity != NULL) {
+            auto* pcComposableEntity = dynamic_cast<CComposableEntity*>(itComponent->second);
+            if(pcComposableEntity != nullptr) {
                /* Dynamic cast of component to composable entity was sucessful, re-execute this function in the new context */
                return pcComposableEntity->HasComponent(str_path.substr(unFirstSeparatorIdx + 1, std::string::npos));
             }

--- a/src/core/simulator/entity/controllable_entity.cpp
+++ b/src/core/simulator/entity/controllable_entity.cpp
@@ -18,7 +18,7 @@ namespace argos {
 
    CControllableEntity::CControllableEntity(CComposableEntity* pc_parent) :
       CEntity(pc_parent),
-      m_pcController(NULL) {}
+      m_pcController(nullptr) {}
 
    /****************************************/
    /****************************************/
@@ -26,14 +26,14 @@ namespace argos {
    CControllableEntity::CControllableEntity(CComposableEntity* pc_parent,
                                             const std::string& str_id) :
       CEntity(pc_parent, str_id),
-      m_pcController(NULL) {
+      m_pcController(nullptr) {
    }
 
    /****************************************/
    /****************************************/
 
    CControllableEntity::~CControllableEntity() {
-      if(m_pcController != NULL) {
+      if(m_pcController != nullptr) {
          delete m_pcController;
       }
    }
@@ -73,12 +73,12 @@ namespace argos {
       m_vecCheckedRays.clear();
       m_vecIntersectionPoints.clear();
       /* Reset sensors */
-      for(CCI_Sensor::TMap::iterator it = m_pcController->GetAllSensors().begin();
+      for(auto it = m_pcController->GetAllSensors().begin();
           it != m_pcController->GetAllSensors().end(); ++it) {
          it->second->Reset();
       }
       /* Reset actuators */
-      for(CCI_Actuator::TMap::iterator it = m_pcController->GetAllActuators().begin();
+      for(auto it = m_pcController->GetAllActuators().begin();
           it != m_pcController->GetAllActuators().end(); ++it) {
          it->second->Reset();
       }
@@ -95,12 +95,12 @@ namespace argos {
       m_vecIntersectionPoints.clear();
       if(m_pcController) {
          /* Destroy sensors */
-         for(CCI_Sensor::TMap::iterator it = m_pcController->GetAllSensors().begin();
+         for(auto it = m_pcController->GetAllSensors().begin();
              it != m_pcController->GetAllSensors().end(); ++it) {
             it->second->Destroy();
          }
          /* Destroy actuators */
-         for(CCI_Actuator::TMap::iterator it = m_pcController->GetAllActuators().begin();
+         for(auto it = m_pcController->GetAllActuators().begin();
              it != m_pcController->GetAllActuators().end(); ++it) {
             it->second->Destroy();
          }
@@ -113,7 +113,7 @@ namespace argos {
    /****************************************/
    
    const CCI_Controller& CControllableEntity::GetController() const {
-      if(m_pcController != NULL) {
+      if(m_pcController != nullptr) {
          return *m_pcController;
       }
       else {
@@ -125,7 +125,7 @@ namespace argos {
    /****************************************/
    
    CCI_Controller& CControllableEntity::GetController() {
-      if(m_pcController != NULL) {
+      if(m_pcController != nullptr) {
          return *m_pcController;
       }
       else {
@@ -164,8 +164,8 @@ namespace argos {
             /* itAct->Value() is the name of the current actuator */
             GetNodeAttribute(*itAct, "implementation", strImpl);
             CSimulatedActuator* pcAct = CFactory<CSimulatedActuator>::New(itAct->Value() + " (" + strImpl + ")");
-            CCI_Actuator* pcCIAct = dynamic_cast<CCI_Actuator*>(pcAct);
-            if(pcCIAct == NULL) {
+            auto* pcCIAct = dynamic_cast<CCI_Actuator*>(pcAct);
+            if(pcCIAct == nullptr) {
                THROW_ARGOSEXCEPTION("BUG: actuator \"" << itAct->Value() << "\" does not inherit from CCI_Actuator");
             }
             pcAct->SetRobot(GetParent());
@@ -182,8 +182,8 @@ namespace argos {
             /* itSens->Value() is the name of the current actuator */
             GetNodeAttribute(*itSens, "implementation", strImpl);
             CSimulatedSensor* pcSens = CFactory<CSimulatedSensor>::New(itSens->Value() + " (" + strImpl + ")");
-            CCI_Sensor* pcCISens = dynamic_cast<CCI_Sensor*>(pcSens);
-            if(pcCISens == NULL) {
+            auto* pcCISens = dynamic_cast<CCI_Sensor*>(pcSens);
+            if(pcCISens == nullptr) {
                THROW_ARGOSEXCEPTION("BUG: sensor \"" << itSens->Value() << "\" does not inherit from CCI_Sensor");
             }
             pcSens->SetRobot(GetParent());
@@ -205,7 +205,7 @@ namespace argos {
    void CControllableEntity::Sense() {
       m_vecCheckedRays.clear();
       m_vecIntersectionPoints.clear();
-      for(std::map<std::string, CSimulatedSensor*>::iterator it = m_mapSensors.begin();
+      for(auto it = m_mapSensors.begin();
           it != m_mapSensors.end(); ++it) {
          it->second->Update();
       }
@@ -215,7 +215,7 @@ namespace argos {
    /****************************************/
 
    void CControllableEntity::ControlStep() {
-      if(m_pcController != NULL) {
+      if(m_pcController != nullptr) {
          m_pcController->ControlStep();
       }
       else {
@@ -227,7 +227,7 @@ namespace argos {
    /****************************************/
 
    void CControllableEntity::Act() {
-      for(std::map<std::string, CSimulatedActuator*>::iterator it = m_mapActuators.begin();
+      for(auto it = m_mapActuators.begin();
           it != m_mapActuators.end(); ++it) {
          it->second->Update();
       }

--- a/src/core/simulator/entity/embodied_entity.cpp
+++ b/src/core/simulator/entity/embodied_entity.cpp
@@ -19,8 +19,8 @@ namespace argos {
    CEmbodiedEntity::CEmbodiedEntity(CComposableEntity* pc_parent) :
       CEntity(pc_parent),
       m_bMovable(true),
-      m_sBoundingBox(NULL),
-      m_psOriginAnchor(NULL) {}
+      m_sBoundingBox(nullptr),
+      m_psOriginAnchor(nullptr) {}
 
    /****************************************/
    /****************************************/
@@ -32,7 +32,7 @@ namespace argos {
                                     bool b_movable) :
       CEntity(pc_parent, str_id),
       m_bMovable(b_movable),
-      m_sBoundingBox(NULL),
+      m_sBoundingBox(nullptr),
       m_psOriginAnchor(new SAnchor(*this,
                                    "origin",
                                    0,
@@ -51,10 +51,10 @@ namespace argos {
    /****************************************/
 
    CEmbodiedEntity::~CEmbodiedEntity() {
-      if(!m_bMovable && m_sBoundingBox != NULL) {
+      if(!m_bMovable && m_sBoundingBox != nullptr) {
          delete m_sBoundingBox;
       }
-      for(std::map<std::string, SAnchor*>::iterator it = m_mapAnchors.begin();
+      for(auto it = m_mapAnchors.begin();
           it != m_mapAnchors.end(); ++it) {
          /* it->second points to the current anchor */
          delete it->second;
@@ -101,7 +101,7 @@ namespace argos {
       m_psOriginAnchor->Orientation = m_cInitOriginOrientation;
       /* Reset other anchors */
       SAnchor* psAnchor;
-      for(std::map<std::string, SAnchor*>::iterator it = m_mapAnchors.begin();
+      for(auto it = m_mapAnchors.begin();
           it != m_mapAnchors.end(); ++it) {
          /* it->second points to the current anchor */
          psAnchor = it->second;
@@ -132,7 +132,7 @@ namespace argos {
       /* Calculate anchor orientation */
       CQuaternion cOrient = m_psOriginAnchor->Orientation * c_offset_orientation;
       /* Create anchor */
-      SAnchor* psAnchor = new SAnchor(*this,
+      auto* psAnchor = new SAnchor(*this,
                                       str_id,
                                       m_mapAnchors.size(),
                                       c_offset_position,
@@ -149,7 +149,7 @@ namespace argos {
 
    void CEmbodiedEntity::EnableAnchor(const std::string& str_id) {
       /* Lookup the anchor id */
-      std::map<std::string, SAnchor*>::iterator it = m_mapAnchors.find(str_id);
+      auto it = m_mapAnchors.find(str_id);
       /* Found? */
       if(it == m_mapAnchors.end()) {
          THROW_ARGOSEXCEPTION("Embodied entity \"" << GetContext() + GetId() << "\" has no anchor with id " << str_id);
@@ -170,7 +170,7 @@ namespace argos {
       /* Cannot disable the origin anchor */
       if(str_id == "origin") return;
       /* Lookup the anchor id */
-      std::vector<SAnchor*>::iterator it = std::find(m_vecEnabledAnchors.begin(),
+      auto it = std::find(m_vecEnabledAnchors.begin(),
                                                      m_vecEnabledAnchors.end(),
                                                      str_id);
       /* Found? */
@@ -189,7 +189,7 @@ namespace argos {
 
    const SAnchor& CEmbodiedEntity::GetAnchor(const std::string& str_id) const {
       /* Lookup the anchor id */
-      std::map<std::string, SAnchor*>::const_iterator it = m_mapAnchors.find(str_id);
+      auto it = m_mapAnchors.find(str_id);
       /* Found? */
       if(it == m_mapAnchors.end()) {
          THROW_ARGOSEXCEPTION("Embodied entity \"" << GetContext() + GetId() << "\" has no anchor with id " << str_id);
@@ -203,7 +203,7 @@ namespace argos {
 
    SAnchor& CEmbodiedEntity::GetAnchor(const std::string& str_id) {
       /* Lookup the anchor id */
-      std::map<std::string, SAnchor*>::iterator it = m_mapAnchors.find(str_id);
+      auto it = m_mapAnchors.find(str_id);
       /* Found? */
       if(it == m_mapAnchors.end()) {
          THROW_ARGOSEXCEPTION("Embodied entity \"" << GetContext() + GetId() << "\" has no anchor with id " << str_id);
@@ -261,11 +261,11 @@ namespace argos {
    /****************************************/
 
    void CEmbodiedEntity::RemovePhysicsModel(const std::string& str_engine_id) {
-      CPhysicsModel::TMap::iterator itMap = m_tPhysicsModelMap.find(str_engine_id);
+      auto itMap = m_tPhysicsModelMap.find(str_engine_id);
       if(itMap == m_tPhysicsModelMap.end()) {
          THROW_ARGOSEXCEPTION("Entity \"" << GetContext() << GetId() << "\" has no associated entity in physics engine " << str_engine_id);
       }
-      CPhysicsModel::TVector::iterator itVec = std::find(m_tPhysicsModelVector.begin(),
+      auto itVec = std::find(m_tPhysicsModelVector.begin(),
                                                          m_tPhysicsModelVector.end(),
                                                          itMap->second);
       m_tPhysicsModelMap.erase(itMap);
@@ -297,7 +297,7 @@ namespace argos {
    /****************************************/
 
    const CPhysicsModel& CEmbodiedEntity::GetPhysicsModel(const std::string& str_engine_id) const {
-      CPhysicsModel::TMap::const_iterator it = m_tPhysicsModelMap.find(str_engine_id);
+      auto it = m_tPhysicsModelMap.find(str_engine_id);
       if(it == m_tPhysicsModelMap.end()) {
          THROW_ARGOSEXCEPTION("Entity \"" << GetContext() << GetId() << "\" has no associated entity in physics engine \"" << str_engine_id << "\"");
       }
@@ -308,7 +308,7 @@ namespace argos {
    /****************************************/
 
    CPhysicsModel& CEmbodiedEntity::GetPhysicsModel(const std::string& str_engine_id) {
-      CPhysicsModel::TMap::iterator it = m_tPhysicsModelMap.find(str_engine_id);
+      auto it = m_tPhysicsModelMap.find(str_engine_id);
       if(it == m_tPhysicsModelMap.end()) {
          THROW_ARGOSEXCEPTION("Entity \"" << GetContext() << GetId() << "\" has no associated entity in physics engine \"" << str_engine_id << "\"");
       }
@@ -389,7 +389,7 @@ namespace argos {
          }
          else {
             /* The bounding box is obtained taking the extrema of all the bboxes of all the engines */
-            if(m_sBoundingBox == NULL) {
+            if(m_sBoundingBox == nullptr) {
                m_sBoundingBox = new SBoundingBox();
             }
             *m_sBoundingBox = m_tPhysicsModelVector[0]->GetBoundingBox();
@@ -408,11 +408,11 @@ namespace argos {
          /*
           * No physics engine entity associated
           */
-         if(! m_bMovable && m_sBoundingBox != NULL) {
+         if(! m_bMovable && m_sBoundingBox != nullptr) {
             /* A non-movable entity has its own bounding box, delete it */
             delete m_sBoundingBox;
          }
-         m_sBoundingBox = NULL;
+         m_sBoundingBox = nullptr;
       }
    }
 

--- a/src/core/simulator/entity/entity.cpp
+++ b/src/core/simulator/entity/entity.cpp
@@ -19,7 +19,7 @@ namespace argos {
       m_pcParent(pc_parent),
       m_nIndex(-1),
       m_bEnabled(true),
-      m_ptConfNode(NULL) {
+      m_ptConfNode(nullptr) {
    }
 
    /****************************************/
@@ -31,7 +31,7 @@ namespace argos {
       m_strId(str_id),
       m_nIndex(-1),
       m_bEnabled(true),
-      m_ptConfNode(NULL) {
+      m_ptConfNode(nullptr) {
    }
 
    /****************************************/
@@ -53,7 +53,7 @@ namespace argos {
          }
          else {
             /* No, derive it from the parent */
-            if(m_pcParent != NULL) {
+            if(m_pcParent != nullptr) {
                UInt32 unIdCount = 0;
                while(GetParent().HasComponent(GetTypeDescription() +
                                               "[" + GetTypeDescription() +
@@ -77,7 +77,7 @@ namespace argos {
    /****************************************/
 
    std::string CEntity::GetContext() const {
-      if(m_pcParent != NULL) {
+      if(m_pcParent != nullptr) {
          return GetParent().GetContext() + GetParent().GetId() + ".";
       }
       else {
@@ -89,7 +89,7 @@ namespace argos {
    /****************************************/
    
    CComposableEntity& CEntity::GetParent() {
-      if(m_pcParent != NULL) {
+      if(m_pcParent != nullptr) {
          return *m_pcParent;
       }
       else {
@@ -101,7 +101,7 @@ namespace argos {
    /****************************************/
 
    const CComposableEntity& CEntity::GetParent() const {
-      if(m_pcParent != NULL) {
+      if(m_pcParent != nullptr) {
          return *m_pcParent;
       }
       else {
@@ -113,7 +113,7 @@ namespace argos {
    /****************************************/
 
    CEntity& CEntity::GetRootEntity() {
-      if(m_pcParent != NULL) {
+      if(m_pcParent != nullptr) {
          return m_pcParent->GetRootEntity();
       }
       else {
@@ -125,7 +125,7 @@ namespace argos {
    /****************************************/
    
    const CEntity& CEntity::GetRootEntity() const {
-      if(m_pcParent != NULL) {
+      if(m_pcParent != nullptr) {
          return m_pcParent->GetRootEntity();
       }
       else {

--- a/src/core/simulator/entity/floor_entity.cpp
+++ b/src/core/simulator/entity/floor_entity.cpp
@@ -168,9 +168,9 @@ namespace argos {
    /****************************************/
 
    CFloorEntity::CFloorEntity() :
-      CEntity(NULL),
+      CEntity(nullptr),
       m_eColorSource(UNSET),
-      m_pcColorSource(NULL),
+      m_pcColorSource(nullptr),
       m_bHasChanged(true) {}
 
    /****************************************/
@@ -179,9 +179,9 @@ namespace argos {
 #ifdef ARGOS_WITH_FREEIMAGE
    CFloorEntity::CFloorEntity(const std::string& str_id,
                               const std::string& str_file_name) :
-      CEntity(NULL, str_id),
+      CEntity(nullptr, str_id),
       m_eColorSource(FROM_IMAGE),
-      m_pcColorSource(NULL),
+      m_pcColorSource(nullptr),
       m_bHasChanged(true) {
       std::string strFileName = str_file_name;
       ExpandEnvVariables(strFileName);
@@ -194,7 +194,7 @@ namespace argos {
 
    CFloorEntity::CFloorEntity(const std::string& str_id,
                               UInt32 un_pixels_per_meter) :
-      CEntity(NULL, str_id),
+      CEntity(nullptr, str_id),
       m_eColorSource(FROM_LOOP_FUNCTIONS),
       m_pcColorSource(new CFloorColorFromLoopFunctions(un_pixels_per_meter)),
       m_bHasChanged(true) {}
@@ -203,7 +203,7 @@ namespace argos {
    /****************************************/
 
    CFloorEntity::~CFloorEntity() {
-      if(m_pcColorSource != NULL) {
+      if(m_pcColorSource != nullptr) {
          delete m_pcColorSource;
       }
    }

--- a/src/core/simulator/physics_engine/physics_engine.cpp
+++ b/src/core/simulator/physics_engine/physics_engine.cpp
@@ -41,7 +41,7 @@ namespace argos {
    bool GetClosestEmbodiedEntityIntersectedByRay(SEmbodiedEntityIntersectionItem& s_item,
                                                  const CRay3& c_ray) {
       /* Initialize s_item */
-      s_item.IntersectedEntity = NULL;
+      s_item.IntersectedEntity = nullptr;
       s_item.TOnRay = 1.0f;
       /* Perform full ray query */
       TEmbodiedEntityIntersectionData tData;
@@ -52,7 +52,7 @@ namespace argos {
             s_item = tData[i];
       }
       /* Return true if an intersection was found */
-      return (s_item.IntersectedEntity != NULL);
+      return (s_item.IntersectedEntity != nullptr);
    }
 
    /****************************************/
@@ -62,7 +62,7 @@ namespace argos {
                                                  const CRay3& c_ray,
                                                  CEmbodiedEntity& c_entity) {
       /* Initialize s_item */
-      s_item.IntersectedEntity = NULL;
+      s_item.IntersectedEntity = nullptr;
       s_item.TOnRay = 1.0f;
       /* Perform full ray query */
       TEmbodiedEntityIntersectionData tData;
@@ -75,7 +75,7 @@ namespace argos {
          }
       }
       /* Return true if an intersection was found */
-      return (s_item.IntersectedEntity != NULL);
+      return (s_item.IntersectedEntity != nullptr);
    }
 
    /****************************************/
@@ -89,8 +89,8 @@ namespace argos {
    /****************************************/
 
    CPhysicsEngine::SVolume::SVolume() :
-      TopFace(NULL),
-      BottomFace(NULL) {
+      TopFace(nullptr),
+      BottomFace(nullptr) {
    }
 
    /****************************************/
@@ -128,7 +128,7 @@ namespace argos {
             while(tVertexIt != tVertexIt.end()) {
                /* Read vertex data and fill in segment struct */
                GetNodeAttribute(*tVertexIt, "point", cCurPoint);
-               SVerticalFace* psFace = new SVerticalFace;
+               auto* psFace = new SVerticalFace;
                psFace->BaseSegment.SetStart(cLastPoint);
                psFace->BaseSegment.SetEnd(cCurPoint);
                SideFaces.push_back(psFace);
@@ -141,7 +141,7 @@ namespace argos {
                THROW_ARGOSEXCEPTION("The <sides> path is not closed; at least 3 segments must be specified");
             }
             if(cLastPoint != cFirstPoint) {
-               SVerticalFace* psFace = new SVerticalFace;
+               auto* psFace = new SVerticalFace;
                psFace->BaseSegment.SetStart(cLastPoint);
                psFace->BaseSegment.SetEnd(cFirstPoint);
                SideFaces.push_back(psFace);

--- a/src/core/simulator/physics_engine/physics_model.cpp
+++ b/src/core/simulator/physics_engine/physics_model.cpp
@@ -46,8 +46,8 @@ namespace argos {
       m_cEngine(c_engine),
       m_cEmbodiedEntity(c_entity),
       m_sBoundingBox(),
-      m_vecAnchorMethodHolders(c_entity.GetAnchors().size(), NULL),
-      m_vecThunks(c_entity.GetAnchors().size(), NULL) {}
+      m_vecAnchorMethodHolders(c_entity.GetAnchors().size(), nullptr),
+      m_vecThunks(c_entity.GetAnchors().size(), nullptr) {}
 
    /****************************************/
    /****************************************/
@@ -61,7 +61,7 @@ namespace argos {
       /* Get a reference to the root entity */
       /* NOTE: here the cast is static because we know that an embodied entity MUST have a parent
        * which, by definition, is a composable entity */
-      CComposableEntity& cRoot = static_cast<CComposableEntity&>(m_cEmbodiedEntity.GetRootEntity());
+      auto& cRoot = static_cast<CComposableEntity&>(m_cEmbodiedEntity.GetRootEntity());
       /* Update its components */
       cRoot.UpdateComponents();
       /*
@@ -77,7 +77,7 @@ namespace argos {
    void CPhysicsModel::CalculateAnchors() {
       std::vector<SAnchor*>& vecAnchors = m_cEmbodiedEntity.GetEnabledAnchors();
       for(size_t i = 0; i < vecAnchors.size(); ++i) {
-         if(m_vecThunks[vecAnchors[i]->Index] != NULL) {
+         if(m_vecThunks[vecAnchors[i]->Index] != nullptr) {
             TThunk tThunk = m_vecThunks[vecAnchors[i]->Index];
             (this->*tThunk)(*vecAnchors[i]);
          }

--- a/src/core/simulator/simulator.cpp
+++ b/src/core/simulator/simulator.cpp
@@ -30,13 +30,13 @@ namespace argos {
    /****************************************/
 
    CSimulator::CSimulator() :
-      m_pcVisualization(NULL),
-      m_pcSpace(NULL),
-      m_pcLoopFunctions(NULL),
+      m_pcVisualization(nullptr),
+      m_pcSpace(nullptr),
+      m_pcLoopFunctions(nullptr),
       m_unMaxSimulationClock(0),
       m_bWasRandomSeedSet(false),
       m_unThreads(0),
-      m_pcProfiler(NULL),
+      m_pcProfiler(nullptr),
       m_bHumanReadableProfile(true),
       m_bRealTimeClock(false),
       m_bTerminated(false) {}
@@ -49,23 +49,23 @@ namespace argos {
          delete m_pcProfiler;
       }
       /* Delete the visualization */
-      if(m_pcVisualization != NULL) delete m_pcVisualization;
+      if(m_pcVisualization != nullptr) delete m_pcVisualization;
       /* Delete all the media */
-      for(CMedium::TMap::iterator it = m_mapMedia.begin();
+      for(auto it = m_mapMedia.begin();
           it != m_mapMedia.end(); ++it) {
          delete it->second;
       }
       m_mapMedia.clear();
       m_vecMedia.clear();
       /* Delete all the physics engines */
-      for(CPhysicsEngine::TMap::iterator it = m_mapPhysicsEngines.begin();
+      for(auto it = m_mapPhysicsEngines.begin();
           it != m_mapPhysicsEngines.end(); ++it) {
          delete it->second;
       }
       m_mapPhysicsEngines.clear();
       m_vecPhysicsEngines.clear();
       /* Delete the space and the dynamic linking manager */
-      if(m_pcSpace != NULL) {
+      if(m_pcSpace != nullptr) {
          delete m_pcSpace;
       }
       /* Get rid of all libraries */
@@ -84,7 +84,7 @@ namespace argos {
    /****************************************/
 
    CPhysicsEngine& CSimulator::GetPhysicsEngine(const std::string& str_id) const {
-      CPhysicsEngine::TMap::const_iterator it = m_mapPhysicsEngines.find(str_id);
+      auto it = m_mapPhysicsEngines.find(str_id);
       ARGOS_ASSERT(it != m_mapPhysicsEngines.end(), "Physics engine \"" << str_id << "\" not found.")
          return *(it->second);
    }
@@ -93,7 +93,7 @@ namespace argos {
    /****************************************/
 
    TConfigurationNode& CSimulator::GetConfigForController(const std::string& str_id) {
-      TControllerConfigurationMap::iterator it = m_mapControllerConfig.find(str_id);
+      auto it = m_mapControllerConfig.find(str_id);
       if(it == m_mapControllerConfig.end()) {
          THROW_ARGOSEXCEPTION("Can't find XML configuration for controller id \"" << str_id << "\"");
       }
@@ -186,8 +186,8 @@ namespace argos {
       else {
          /* Prepare the default value based on the current clock time */
          struct timeval sTimeValue;
-         ::gettimeofday(&sTimeValue, NULL);
-         UInt32 unSeed = static_cast<UInt32>(sTimeValue.tv_usec);
+         ::gettimeofday(&sTimeValue, nullptr);
+         auto unSeed = static_cast<UInt32>(sTimeValue.tv_usec);
          CRandom::SetSeedOf("argos", unSeed);
          m_unRandomSeed = unSeed;
          LOG << "[INFO] Using random seed = " << m_unRandomSeed << std::endl;
@@ -196,12 +196,12 @@ namespace argos {
       /* Reset the space */
       m_pcSpace->Reset();
       /* Reset the media */
-      for(CMedium::TMap::iterator it = m_mapMedia.begin();
+      for(auto it = m_mapMedia.begin();
           it != m_mapMedia.end(); ++it) {
          it->second->Reset();
       }
       /* Reset the physics engines */
-      for(CPhysicsEngine::TMap::iterator it = m_mapPhysicsEngines.begin();
+      for(auto it = m_mapPhysicsEngines.begin();
           it != m_mapPhysicsEngines.end(); ++it) {
          it->second->Reset();
       }
@@ -216,21 +216,21 @@ namespace argos {
 
    void CSimulator::Destroy() {
       /* Call user destroy function */
-      if (m_pcLoopFunctions != NULL) {
+      if (m_pcLoopFunctions != nullptr) {
          m_pcLoopFunctions->Destroy();
          delete m_pcLoopFunctions;
-         m_pcLoopFunctions = NULL;
+         m_pcLoopFunctions = nullptr;
       }
       /* Destroy the visualization */
-      if(m_pcVisualization != NULL) {
+      if(m_pcVisualization != nullptr) {
          m_pcVisualization->Destroy();
       }
       /* Destroy simulated space */
-      if(m_pcSpace != NULL) {
+      if(m_pcSpace != nullptr) {
          m_pcSpace->Destroy();
       }
       /* Destroy media */
-      for(CMedium::TMap::iterator it = m_mapMedia.begin();
+      for(auto it = m_mapMedia.begin();
           it != m_mapMedia.end(); ++it) {
          it->second->Destroy();
          delete it->second;
@@ -238,7 +238,7 @@ namespace argos {
       m_mapMedia.clear();
       m_vecMedia.clear();
       /* Destroy physics engines */
-      for(CPhysicsEngine::TMap::iterator it = m_mapPhysicsEngines.begin();
+      for(auto it = m_mapPhysicsEngines.begin();
           it != m_mapPhysicsEngines.end(); ++it) {
          it->second->Destroy();
          delete it->second;
@@ -360,8 +360,8 @@ namespace argos {
             /* Prepare the default value based on the current clock time */
             m_bWasRandomSeedSet = false;
             struct timeval sTimeValue;
-            ::gettimeofday(&sTimeValue, NULL);
-            UInt32 unSeed = static_cast<UInt32>(sTimeValue.tv_usec);
+            ::gettimeofday(&sTimeValue, nullptr);
+            auto unSeed = static_cast<UInt32>(sTimeValue.tv_usec);
             m_unRandomSeed = unSeed;
             CRandom::CreateCategory("argos", unSeed);
             LOG << "[INFO] Using random seed = " << unSeed << std::endl;

--- a/src/core/simulator/space/space.cpp
+++ b/src/core/simulator/space/space.cpp
@@ -27,9 +27,9 @@ namespace argos {
    CSpace::CSpace() :
       m_cSimulator(CSimulator::GetInstance()),
       m_unSimulationClock(0),
-      m_pcFloorEntity(NULL),
-      m_ptPhysicsEngines(NULL),
-      m_ptMedia(NULL) {}
+      m_pcFloorEntity(nullptr),
+      m_ptPhysicsEngines(nullptr),
+      m_ptMedia(nullptr) {}
 
    /****************************************/
    /****************************************/
@@ -94,7 +94,7 @@ namespace argos {
 
    void CSpace::GetEntitiesMatching(CEntity::TVector& t_buffer,
                                     const std::string& str_pattern) {
-      for(CEntity::TVector::iterator it = m_vecEntities.begin();
+      for(auto it = m_vecEntities.begin();
           it != m_vecEntities.end(); ++it) {
          if(MatchPattern((*it)->GetId(), str_pattern)) {
             t_buffer.push_back(*it);
@@ -106,7 +106,7 @@ namespace argos {
    /****************************************/
 
    CSpace::TMapPerType& CSpace::GetEntitiesByTypeImpl(const std::string& str_type) const {
-     TMapPerTypePerId::const_iterator itEntities = m_mapEntitiesPerTypePerId.find(str_type);
+     auto itEntities = m_mapEntitiesPerTypePerId.find(str_type);
      if(itEntities != m_mapEntitiesPerTypePerId.end()){
        return const_cast<CSpace::TMapPerType&>(itEntities->second);
      } else {
@@ -147,7 +147,7 @@ namespace argos {
    /****************************************/
 
    void CSpace::RemoveControllableEntity(CControllableEntity& c_entity) {
-      CControllableEntity::TVector::iterator it = find(m_vecControllableEntities.begin(),
+      auto it = find(m_vecControllableEntities.begin(),
                                                        m_vecControllableEntities.end(),
                                                        &c_entity);
       if(it != m_vecControllableEntities.end()) {
@@ -367,19 +367,19 @@ namespace argos {
 
    static CEmbodiedEntity* GetEmbodiedEntity(CEntity* pc_entity) {
       /* Is the entity embodied itself? */
-      CEmbodiedEntity* pcEmbodiedTest = dynamic_cast<CEmbodiedEntity*>(pc_entity);
-      if(pcEmbodiedTest != NULL) {
+      auto* pcEmbodiedTest = dynamic_cast<CEmbodiedEntity*>(pc_entity);
+      if(pcEmbodiedTest != nullptr) {
          return pcEmbodiedTest;
       }
       /* Is the entity composable with an embodied component? */
-      CComposableEntity* pcComposableTest = dynamic_cast<CComposableEntity*>(pc_entity);
-      if(pcComposableTest != NULL) {
+      auto* pcComposableTest = dynamic_cast<CComposableEntity*>(pc_entity);
+      if(pcComposableTest != nullptr) {
          if(pcComposableTest->HasComponent("body")) {
             return &(pcComposableTest->GetComponent<CEmbodiedEntity>("body"));
          }
       }
       /* No embodied entity found */
-      return NULL;
+      return nullptr;
    }
 
    /****************************************/
@@ -387,19 +387,19 @@ namespace argos {
 
    static CPositionalEntity* GetPositionalEntity(CEntity* pc_entity) {
       /* Is the entity positional itself? */
-      CPositionalEntity* pcPositionalTest = dynamic_cast<CPositionalEntity*>(pc_entity);
-      if(pcPositionalTest != NULL) {
+      auto* pcPositionalTest = dynamic_cast<CPositionalEntity*>(pc_entity);
+      if(pcPositionalTest != nullptr) {
          return pcPositionalTest;
       }
       /* Is the entity composable with a positional component? */
-      CComposableEntity* pcComposableTest = dynamic_cast<CComposableEntity*>(pc_entity);
-      if(pcComposableTest != NULL) {
+      auto* pcComposableTest = dynamic_cast<CComposableEntity*>(pc_entity);
+      if(pcComposableTest != nullptr) {
          if(pcComposableTest->HasComponent("position")) {
             return &(pcComposableTest->GetComponent<CPositionalEntity>("position"));
          }
       }
       /* No positional entity found */
-      return NULL;
+      return nullptr;
    }
 
    /****************************************/
@@ -470,7 +470,7 @@ namespace argos {
                 */
                /* Check whether the entity is positional */
                CPositionalEntity* pcPositionalEntity = GetPositionalEntity(pcEntity);
-               if(pcPositionalEntity != NULL) {
+               if(pcPositionalEntity != nullptr) {
                   /* Set the position */
                   SetNodeAttribute(tEntityTree, "position", (*pcPositionGenerator)(bRetry));
                   /* Set the orientation */
@@ -498,7 +498,7 @@ namespace argos {
                   pcEntity->Init(tEntityTree);
                   /* Check whether the entity is indeed embodied */
                   CEmbodiedEntity* pcEmbodiedEntity = GetEmbodiedEntity(pcEntity);
-                  if(pcEmbodiedEntity != NULL) {
+                  if(pcEmbodiedEntity != nullptr) {
                      /* Yes, the entity is embodied */
                      /* Add it to the space and to the designated physics engine */
                      CallEntityOperation<CSpaceOperationAddEntity, CSpace, void>(*this, *pcEntity);

--- a/src/core/simulator/space/space_multi_thread_balance_length.cpp
+++ b/src/core/simulator/space/space_multi_thread_balance_length.cpp
@@ -40,10 +40,10 @@ namespace argos {
       LOG.AddThreadSafeBuffer();
       LOGERR.AddThreadSafeBuffer();
       /* Make this thread cancellable */
-      pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-      pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+      pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
+      pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, nullptr);
       /* Get a handle to the thread launch data */
-      CSpaceMultiThreadBalanceLength::SThreadLaunchData* psData = reinterpret_cast<CSpaceMultiThreadBalanceLength::SThreadLaunchData*>(p_data);
+      auto* psData = reinterpret_cast<CSpaceMultiThreadBalanceLength::SThreadLaunchData*>(p_data);
       /* Create cancellation data */
       SCleanupThreadData sCancelData;
       sCancelData.StartSenseControlPhaseMutex = &(psData->Space->m_tStartSenseControlPhaseMutex);
@@ -55,7 +55,7 @@ namespace argos {
       psData->Space->SlaveThread();
       /* Dispose of cancellation data */
       pthread_cleanup_pop(1);
-      return NULL;
+      return nullptr;
    }
 
    /****************************************/
@@ -67,19 +67,19 @@ namespace argos {
       /* Initialize thread related structures */
       int nErrors;
       /* Init mutexes */
-      if((nErrors = pthread_mutex_init(&m_tStartSenseControlPhaseMutex, NULL)) ||
-         (nErrors = pthread_mutex_init(&m_tStartActPhaseMutex, NULL)) ||
-         (nErrors = pthread_mutex_init(&m_tStartPhysicsPhaseMutex, NULL)) ||
-         (nErrors = pthread_mutex_init(&m_tStartMediaPhaseMutex, NULL)) ||
-         (nErrors = pthread_mutex_init(&m_tFetchTaskMutex, NULL))) {
+      if((nErrors = pthread_mutex_init(&m_tStartSenseControlPhaseMutex, nullptr)) ||
+         (nErrors = pthread_mutex_init(&m_tStartActPhaseMutex, nullptr)) ||
+         (nErrors = pthread_mutex_init(&m_tStartPhysicsPhaseMutex, nullptr)) ||
+         (nErrors = pthread_mutex_init(&m_tStartMediaPhaseMutex, nullptr)) ||
+         (nErrors = pthread_mutex_init(&m_tFetchTaskMutex, nullptr))) {
          THROW_ARGOSEXCEPTION("Error creating thread mutexes " << ::strerror(nErrors));
       }
       /* Init conditionals */
-      if((nErrors = pthread_cond_init(&m_tStartSenseControlPhaseCond, NULL)) ||
-         (nErrors = pthread_cond_init(&m_tStartActPhaseCond, NULL)) ||
-         (nErrors = pthread_cond_init(&m_tStartPhysicsPhaseCond, NULL)) ||
-         (nErrors = pthread_cond_init(&m_tStartMediaPhaseCond, NULL)) ||
-         (nErrors = pthread_cond_init(&m_tFetchTaskCond, NULL))) {
+      if((nErrors = pthread_cond_init(&m_tStartSenseControlPhaseCond, nullptr)) ||
+         (nErrors = pthread_cond_init(&m_tStartActPhaseCond, nullptr)) ||
+         (nErrors = pthread_cond_init(&m_tStartPhysicsPhaseCond, nullptr)) ||
+         (nErrors = pthread_cond_init(&m_tStartMediaPhaseCond, nullptr)) ||
+         (nErrors = pthread_cond_init(&m_tFetchTaskCond, nullptr))) {
          THROW_ARGOSEXCEPTION("Error creating thread conditionals " << ::strerror(nErrors));
       }
       /* Reset the idle thread count */
@@ -97,13 +97,13 @@ namespace argos {
    void CSpaceMultiThreadBalanceLength::Destroy() {
       /* Destroy the threads to update the controllable entities */
       int nErrors;
-      if(m_ptThreads != NULL) {
+      if(m_ptThreads != nullptr) {
          for(UInt32 i = 0; i < CSimulator::GetInstance().GetNumThreads(); ++i) {
             if((nErrors = pthread_cancel(m_ptThreads[i]))) {
                THROW_ARGOSEXCEPTION("Error canceling threads " << ::strerror(nErrors));
             }
          }
-         void** ppJoinResult = new void*[CSimulator::GetInstance().GetNumThreads()];
+         auto** ppJoinResult = new void*[CSimulator::GetInstance().GetNumThreads()];
          for(UInt32 i = 0; i < CSimulator::GetInstance().GetNumThreads(); ++i) {
             if((nErrors = pthread_join(m_ptThreads[i], ppJoinResult + i))) {
                THROW_ARGOSEXCEPTION("Error joining threads " << ::strerror(nErrors));
@@ -116,7 +116,7 @@ namespace argos {
       }
       delete[] m_ptThreads;
       /* Destroy the thread launch info */
-      if(m_psThreadData != NULL) {
+      if(m_psThreadData != nullptr) {
          for(UInt32 i = 0; i < CSimulator::GetInstance().GetNumThreads(); ++i) {
             delete m_psThreadData[i];
          }
@@ -219,7 +219,7 @@ namespace argos {
          m_psThreadData[i] = new SThreadLaunchData(i, this);
          /* Create the thread */
          if((nErrors = pthread_create(m_ptThreads + i,
-                                      NULL,
+                                      nullptr,
                                       LaunchThreadBalanceLength,
                                       reinterpret_cast<void*>(m_psThreadData[i])))) {
             THROW_ARGOSEXCEPTION("Error creating thread: " << ::strerror(nErrors));

--- a/src/core/simulator/space/space_multi_thread_balance_quantity.cpp
+++ b/src/core/simulator/space/space_multi_thread_balance_quantity.cpp
@@ -38,17 +38,17 @@ namespace argos {
    void* LaunchUpdateThreadBalanceQuantity(void* p_data) {
       LOG.AddThreadSafeBuffer();
       LOGERR.AddThreadSafeBuffer();
-      CSpaceMultiThreadBalanceQuantity::SUpdateThreadData* psData = reinterpret_cast<CSpaceMultiThreadBalanceQuantity::SUpdateThreadData*>(p_data);
+      auto* psData = reinterpret_cast<CSpaceMultiThreadBalanceQuantity::SUpdateThreadData*>(p_data);
       psData->Space->UpdateThread(psData->ThreadId);
-      return NULL;
+      return nullptr;
    }
 
    /****************************************/
    /****************************************/
 
    CSpaceMultiThreadBalanceQuantity::CSpaceMultiThreadBalanceQuantity() :
-      m_psUpdateThreadData(NULL),
-      m_ptUpdateThreads(NULL),
+      m_psUpdateThreadData(nullptr),
+      m_ptUpdateThreads(nullptr),
       m_bIsControllableEntityAssignmentRecalculationNeeded(true) {}
 
    /****************************************/
@@ -65,17 +65,17 @@ namespace argos {
       m_unPhysicsPhaseDoneCounter = CSimulator::GetInstance().GetNumThreads();
       m_unMediaPhaseDoneCounter = CSimulator::GetInstance().GetNumThreads();
       /* Then the mutexes */
-      if((nErrors = pthread_mutex_init(&m_tSenseControlStepConditionalMutex, NULL)) ||
-         (nErrors = pthread_mutex_init(&m_tActConditionalMutex, NULL)) ||
-         (nErrors = pthread_mutex_init(&m_tPhysicsConditionalMutex, NULL)) ||
-         (nErrors = pthread_mutex_init(&m_tMediaConditionalMutex, NULL))) {
+      if((nErrors = pthread_mutex_init(&m_tSenseControlStepConditionalMutex, nullptr)) ||
+         (nErrors = pthread_mutex_init(&m_tActConditionalMutex, nullptr)) ||
+         (nErrors = pthread_mutex_init(&m_tPhysicsConditionalMutex, nullptr)) ||
+         (nErrors = pthread_mutex_init(&m_tMediaConditionalMutex, nullptr))) {
          THROW_ARGOSEXCEPTION("Error creating thread mutexes " << ::strerror(nErrors));
       }
       /* Finally the conditionals */
-      if((nErrors = pthread_cond_init(&m_tSenseControlStepConditional, NULL)) ||
-         (nErrors = pthread_cond_init(&m_tActConditional, NULL)) ||
-         (nErrors = pthread_cond_init(&m_tPhysicsConditional, NULL)) ||
-         (nErrors = pthread_cond_init(&m_tMediaConditional, NULL))) {
+      if((nErrors = pthread_cond_init(&m_tSenseControlStepConditional, nullptr)) ||
+         (nErrors = pthread_cond_init(&m_tActConditional, nullptr)) ||
+         (nErrors = pthread_cond_init(&m_tPhysicsConditional, nullptr)) ||
+         (nErrors = pthread_cond_init(&m_tMediaConditional, nullptr))) {
          THROW_ARGOSEXCEPTION("Error creating thread conditionals " << ::strerror(nErrors));
       }
       /* Start threads */
@@ -95,7 +95,7 @@ namespace argos {
          m_psUpdateThreadData[i] = new SUpdateThreadData(i, this);
          /* Create the thread */
          if((nErrors = pthread_create(m_ptUpdateThreads + i,
-                                      NULL,
+                                      nullptr,
                                       LaunchUpdateThreadBalanceQuantity,
                                       reinterpret_cast<void*>(m_psUpdateThreadData[i])))) {
             THROW_ARGOSEXCEPTION("Error creating thread: " << ::strerror(nErrors));
@@ -109,13 +109,13 @@ namespace argos {
    void CSpaceMultiThreadBalanceQuantity::Destroy() {
       /* Destroy the threads to update the controllable entities */
       int nErrors;
-      if(m_ptUpdateThreads != NULL) {
+      if(m_ptUpdateThreads != nullptr) {
          for(UInt32 i = 0; i < CSimulator::GetInstance().GetNumThreads(); ++i) {
             if((nErrors = pthread_cancel(m_ptUpdateThreads[i]))) {
                THROW_ARGOSEXCEPTION("Error canceling controllable entities update threads " << ::strerror(nErrors));
             }
          }
-         void** ppJoinResult = new void*[CSimulator::GetInstance().GetNumThreads()];
+         auto** ppJoinResult = new void*[CSimulator::GetInstance().GetNumThreads()];
          for(UInt32 i = 0; i < CSimulator::GetInstance().GetNumThreads(); ++i) {
             if((nErrors = pthread_join(m_ptUpdateThreads[i], ppJoinResult + i))) {
                THROW_ARGOSEXCEPTION("Error joining controllable entities update threads " << ::strerror(nErrors));
@@ -128,7 +128,7 @@ namespace argos {
       }
       delete[] m_ptUpdateThreads;
       /* Destroy the thread launch info */
-      if(m_psUpdateThreadData != NULL) {
+      if(m_psUpdateThreadData != nullptr) {
          for(UInt32 i = 0; i < CSimulator::GetInstance().GetNumThreads(); ++i) {
             delete m_psUpdateThreadData[i];
          }

--- a/src/core/simulator/visualization/default_visualization.cpp
+++ b/src/core/simulator/visualization/default_visualization.cpp
@@ -31,7 +31,7 @@ namespace argos {
          m_tStepFunction = &CDefaultVisualization::RealTimeStep;
          timerclear(&m_tStepClockTime);
          m_tStepClockTime.tv_usec = 1e6 * CPhysicsEngine::GetSimulationClockTick();
-         ::gettimeofday(&m_tStepStartTime, NULL);
+         ::gettimeofday(&m_tStepStartTime, nullptr);
       }
       else {
          /* Use normal clock */
@@ -67,7 +67,7 @@ namespace argos {
       /* m_tStepStartTime has already been set */
       m_cSimulator.UpdateSpace();
       /* Take the time now */
-      ::gettimeofday(&m_tStepEndTime, NULL);
+      ::gettimeofday(&m_tStepEndTime, nullptr);
       /* Calculate the elapsed time */
       timersub(&m_tStepEndTime, &m_tStepStartTime, &m_tStepElapsedTime);
       /* If the elapsed time is lower than the tick length, wait */
@@ -77,7 +77,7 @@ namespace argos {
          /* Wait */
          ::usleep(m_tStepWaitTime.tv_sec * 1e6 + m_tStepWaitTime.tv_usec);
          /* Get the new step end */
-         ::gettimeofday(&m_tStepEndTime, NULL);
+         ::gettimeofday(&m_tStepEndTime, nullptr);
       }
       else {
          LOGERR << "[WARNING] Clock tick took "

--- a/src/core/utility/datatypes/byte_array.cpp
+++ b/src/core/utility/datatypes/byte_array.cpp
@@ -174,7 +174,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator<<(UInt16 un_value) {
       un_value = htons(un_value);
-      UInt8* punByte = reinterpret_cast<UInt8*>(&un_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&un_value);
       m_vecBuffer.push_back(punByte[0]);
       m_vecBuffer.push_back(punByte[1]);
       return *this;
@@ -185,7 +185,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator>>(UInt16& un_value) {
       if(Size() < 2) THROW_ARGOSEXCEPTION("Attempting to extract too many bytes from byte array (2 requested, " << Size() << " available)");
-      UInt8* punByte = reinterpret_cast<UInt8*>(&un_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&un_value);
       punByte[0] = m_vecBuffer[0];
       punByte[1] = m_vecBuffer[1];
       m_vecBuffer.erase(m_vecBuffer.begin(), m_vecBuffer.begin() + 2);
@@ -198,7 +198,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator<<(SInt16 n_value) {
       n_value = htons(n_value);
-      UInt8* punByte = reinterpret_cast<UInt8*>(&n_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&n_value);
       m_vecBuffer.push_back(punByte[0]);
       m_vecBuffer.push_back(punByte[1]);
       return *this;
@@ -209,7 +209,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator>>(SInt16& n_value) {
       if(Size() < 2) THROW_ARGOSEXCEPTION("Attempting to extract too many bytes from byte array (2 requested, " << Size() << " available)");
-      UInt8* punByte = reinterpret_cast<UInt8*>(&n_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&n_value);
       punByte[0] = m_vecBuffer[0];
       punByte[1] = m_vecBuffer[1];
       m_vecBuffer.erase(m_vecBuffer.begin(), m_vecBuffer.begin() + 2);
@@ -222,7 +222,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator<<(UInt32 un_value) {
       un_value = htonl(un_value);
-      UInt8* punByte = reinterpret_cast<UInt8*>(&un_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&un_value);
       m_vecBuffer.push_back(punByte[0]);
       m_vecBuffer.push_back(punByte[1]);
       m_vecBuffer.push_back(punByte[2]);
@@ -235,7 +235,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator>>(UInt32& un_value) {
       if(Size() < 4) THROW_ARGOSEXCEPTION("Attempting to extract too many bytes from byte array (4 requested, " << Size() << " available)");
-      UInt8* punByte = reinterpret_cast<UInt8*>(&un_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&un_value);
       punByte[0] = m_vecBuffer[0];
       punByte[1] = m_vecBuffer[1];
       punByte[2] = m_vecBuffer[2];
@@ -250,7 +250,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator<<(SInt32 n_value) {
       n_value = htonl(n_value);
-      UInt8* punByte = reinterpret_cast<UInt8*>(&n_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&n_value);
       m_vecBuffer.push_back(punByte[0]);
       m_vecBuffer.push_back(punByte[1]);
       m_vecBuffer.push_back(punByte[2]);
@@ -263,7 +263,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator>>(SInt32& n_value) {
       if(Size() < 4) THROW_ARGOSEXCEPTION("Attempting to extract too many bytes from byte array (4 requested, " << Size() << " available)");
-      UInt8* punByte = reinterpret_cast<UInt8*>(&n_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&n_value);
       punByte[0] = m_vecBuffer[0];
       punByte[1] = m_vecBuffer[1];
       punByte[2] = m_vecBuffer[2];
@@ -278,7 +278,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator<<(UInt64 un_value) {
       un_value = htonll(un_value);
-      UInt8* punByte = reinterpret_cast<UInt8*>(&un_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&un_value);
       m_vecBuffer.push_back(punByte[0]);
       m_vecBuffer.push_back(punByte[1]);
       m_vecBuffer.push_back(punByte[2]);
@@ -295,7 +295,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator>>(UInt64& un_value) {
       if(Size() < 8) THROW_ARGOSEXCEPTION("Attempting to extract too many bytes from byte array (8 requested, " << Size() << " available)");         
-      UInt8* punByte = reinterpret_cast<UInt8*>(&un_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&un_value);
       punByte[0] = m_vecBuffer[0];
       punByte[1] = m_vecBuffer[1];
       punByte[2] = m_vecBuffer[2];
@@ -314,7 +314,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator<<(SInt64 n_value) {
       n_value = htonll(n_value);
-      UInt8* punByte = reinterpret_cast<UInt8*>(&n_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&n_value);
       m_vecBuffer.push_back(punByte[0]);
       m_vecBuffer.push_back(punByte[1]);
       m_vecBuffer.push_back(punByte[2]);
@@ -331,7 +331,7 @@ namespace argos {
 
    CByteArray& CByteArray::operator>>(SInt64& n_value) {
       if(Size() < 8) THROW_ARGOSEXCEPTION("Attempting to extract too many bytes from byte array (8 requested, " << Size() << " available)");         
-      UInt8* punByte = reinterpret_cast<UInt8*>(&n_value);
+      auto* punByte = reinterpret_cast<UInt8*>(&n_value);
       punByte[0] = m_vecBuffer[0];
       punByte[1] = m_vecBuffer[1];
       punByte[2] = m_vecBuffer[2];

--- a/src/core/utility/math/convex_hull.cpp
+++ b/src/core/utility/math/convex_hull.cpp
@@ -42,7 +42,7 @@ namespace argos {
                   vec_edges[arr_vertices[un_idx_i]][arr_vertices[un_idx_j]];
                for(UInt32 un_idx_k = 0; un_idx_k < arr_vertices.size(); un_idx_k++) {
                   if(un_idx_k != un_idx_i && un_idx_k != un_idx_j) {
-                     std::vector<UInt32>::iterator itErase =
+                     auto itErase =
                         std::find(std::begin(tEdge), std::end(tEdge), arr_vertices[un_idx_k]);
                      if(itErase != std::end(tEdge)) {
                         tEdge.erase(itErase);
@@ -116,7 +116,7 @@ namespace argos {
          const CVector3& cPoint = m_vecPoints[un_idx_point];
 
          /* check if this point was already used */
-         std::array<UInt32, 4>::iterator itPoint =
+         auto itPoint =
             std::find(std::begin(arrInitialPoints), std::end(arrInitialPoints), un_idx_point);
          if(itPoint != std::end(arrInitialPoints)) {
             continue;
@@ -127,7 +127,7 @@ namespace argos {
                Erase(m_vecEdge, s_face.VertexIndices);
             }
          }       
-         std::vector<SFace>::iterator itEraseFrom = 
+         auto itEraseFrom = 
             std::remove_if(std::begin(m_vecFaces), std::end(m_vecFaces), [cPoint] (const SFace& s_face) {
                return (s_face.Normal.DotProduct(cPoint) > s_face.Direction + 0.000001);
             });

--- a/src/core/utility/math/rng.cpp
+++ b/src/core/utility/math/rng.cpp
@@ -298,7 +298,7 @@ namespace argos {
    bool CRandom::CreateCategory(const std::string& str_category,
                                 UInt32 un_seed) {
       /* Is there a category already? */
-      std::map<std::string, CCategory*>::iterator itCategory = m_mapCategories.find(str_category);
+      auto itCategory = m_mapCategories.find(str_category);
       if(itCategory == m_mapCategories.end()) {
          /* No, create it */
          m_mapCategories.insert(
@@ -370,7 +370,7 @@ namespace argos {
    /****************************************/
 
    void CRandom::Reset() {
-      for(std::map<std::string, CCategory*>::iterator itCategory = m_mapCategories.begin();
+      for(auto itCategory = m_mapCategories.begin();
           itCategory != m_mapCategories.end();
           ++itCategory) {
          itCategory->second->ResetRNGs();

--- a/src/core/utility/networking/tcp_socket.cpp
+++ b/src/core/utility/networking/tcp_socket.cpp
@@ -75,9 +75,9 @@ namespace argos {
       }
       /* Bind on the first interface available */
       m_nStream = -1;
-      ::addrinfo* ptInterface = NULL;
+      ::addrinfo* ptInterface = nullptr;
       for(ptInterface = ptInterfaceInfo;
-          (ptInterface != NULL) && (m_nStream == -1);
+          (ptInterface != nullptr) && (m_nStream == -1);
           ptInterface = ptInterface->ai_next) {
          m_nStream = ::socket(ptInterface->ai_family,
                               ptInterface->ai_socktype,
@@ -107,7 +107,7 @@ namespace argos {
       tHints.ai_family = AF_INET;       /* Only IPv4 is accepted */
       tHints.ai_socktype = SOCK_STREAM; /* TCP socket */
       tHints.ai_flags = AI_PASSIVE;     /* Necessary for bind() later on */
-      nRetVal = ::getaddrinfo(NULL,
+      nRetVal = ::getaddrinfo(nullptr,
                               ToString(n_port).c_str(),
                               &tHints,
                               &ptInterfaceInfo);
@@ -116,9 +116,9 @@ namespace argos {
       }
       /* Bind on the first interface available */
       m_nStream = -1;
-      ::addrinfo* ptInterface = NULL;
+      ::addrinfo* ptInterface = nullptr;
       for(ptInterface = ptInterfaceInfo;
-          (ptInterface != NULL) && (m_nStream == -1);
+          (ptInterface != nullptr) && (m_nStream == -1);
           ptInterface = ptInterface->ai_next) {
          m_nStream = ::socket(ptInterface->ai_family,
                               ptInterface->ai_socktype,

--- a/src/core/utility/plugins/dynamic_loading.cpp
+++ b/src/core/utility/plugins/dynamic_loading.cpp
@@ -34,13 +34,13 @@ namespace argos {
       /* Try loading without changes to the given path */
       CDynamicLoading::TDLHandle tHandle = ::dlopen(str_lib.c_str(), RTLD_GLOBAL | RTLD_LAZY);
       str_msg += "\n  " + str_lib + ": ";
-      if(tHandle == NULL) {
+      if(tHandle == nullptr) {
          str_msg += dlerror();
          /* Try adding the shared lib extension to the path */
          std::string strLibWExt = str_lib + "." + ARGOS_SHARED_LIBRARY_EXTENSION;
          tHandle = ::dlopen(strLibWExt.c_str(), RTLD_GLOBAL | RTLD_LAZY);
          str_msg += "\n\n  " + strLibWExt + ": ";
-         if(tHandle != NULL) {
+         if(tHandle != nullptr) {
             /* Success */
             str_lib = strLibWExt;
          }
@@ -50,7 +50,7 @@ namespace argos {
             strLibWExt = str_lib + "." + ARGOS_MODULE_LIBRARY_EXTENSION;
             tHandle = ::dlopen(strLibWExt.c_str(), RTLD_GLOBAL | RTLD_LAZY);
             str_msg += "\n\n  " + strLibWExt + ": ";
-            if(tHandle != NULL) {
+            if(tHandle != nullptr) {
                /* Success */
                str_lib = strLibWExt;
             }
@@ -60,7 +60,7 @@ namespace argos {
             }
          }
       }
-      if(tHandle != NULL) {
+      if(tHandle != nullptr) {
          str_msg += "OK";
       }
       return tHandle;
@@ -77,7 +77,7 @@ namespace argos {
           * Absolute path
           */
          /* First check if the library is already loaded */
-         TDLHandleMap::iterator it = m_tOpenLibs.find(str_lib);
+         auto it = m_tOpenLibs.find(str_lib);
          if(it != m_tOpenLibs.end()) {
             /* Already loaded */
             return m_tOpenLibs[str_lib];
@@ -86,7 +86,7 @@ namespace argos {
          std::string strLoadedLib = str_lib;
          std::string strMsg;
          tHandle = LoadLibraryTryingExtensions(strLoadedLib, strMsg);
-         if(tHandle == NULL) {
+         if(tHandle == nullptr) {
             THROW_ARGOSEXCEPTION("Can't load library \""
                                  << str_lib
                                  << "\" after trying the following: "
@@ -108,7 +108,7 @@ namespace argos {
          /* String to store the list of paths to search */
          std::string strPluginPath = ".:" + DEFAULT_PLUGIN_PATH;
          /* Get variable ARGOS_PLUGIN_PATH from the environment */
-         if(::getenv("ARGOS_PLUGIN_PATH") != NULL) {
+         if(::getenv("ARGOS_PLUGIN_PATH") != nullptr) {
             /* Add value of the variable to list of paths to check */
             strPluginPath = std::string(::getenv("ARGOS_PLUGIN_PATH")) + ":" + strPluginPath;
          }
@@ -129,14 +129,14 @@ namespace argos {
             }
             strLibPath = strDir + str_lib;
             /* First check if the library is already loaded */
-            TDLHandleMap::iterator it = m_tOpenLibs.find(strLibPath);
+            auto it = m_tOpenLibs.find(strLibPath);
             if(it != m_tOpenLibs.end()) {
                /* Already loaded */
                return m_tOpenLibs[strLibPath];
             }
             /* Not already loaded, try and load the library */
             tHandle = LoadLibraryTryingExtensions(strLibPath, strMsg);
-            if(tHandle != NULL) {
+            if(tHandle != nullptr) {
                /* Store the handle to the loaded library */
                m_tOpenLibs[strLibPath] = tHandle;
                LOG << "[INFO] Loaded library \"" << strLibPath << "\"" << std::endl;
@@ -157,7 +157,7 @@ namespace argos {
    /****************************************/
 
    void CDynamicLoading::UnloadLibrary(const std::string& str_lib) {
-      TDLHandleMap::iterator it = m_tOpenLibs.find(str_lib);
+      auto it = m_tOpenLibs.find(str_lib);
       if(it != m_tOpenLibs.end()) {
          if(::dlclose(it->second) != 0) {
             LOGERR << "[WARNING] Can't unload library \""
@@ -184,7 +184,7 @@ namespace argos {
       /* String to store the list of paths to search */
       std::string strPluginPath = DEFAULT_PLUGIN_PATH;
       /* Get variable ARGOS_PLUGIN_PATH from the environment */
-      if(::getenv("ARGOS_PLUGIN_PATH") != NULL) {
+      if(::getenv("ARGOS_PLUGIN_PATH") != nullptr) {
          /* Add value of the variable to list of paths to check */
          strPluginPath = std::string(::getenv("ARGOS_PLUGIN_PATH")) + ":" + strPluginPath;
       }
@@ -208,9 +208,9 @@ namespace argos {
          }
          /* Try to open the directory */
          ptDir = ::opendir(strDir.c_str());
-         if(ptDir != NULL) {
+         if(ptDir != nullptr) {
             /* Directory open, now go through the files in the directory */
-            while((ptDirData = ::readdir(ptDir)) != NULL) {
+            while((ptDirData = ::readdir(ptDir)) != nullptr) {
                /* We have a file, check that it is a library file */
                if(strlen(ptDirData->d_name) > strlen(ARGOS_SHARED_LIBRARY_EXTENSION) &&
                   std::string(ptDirData->d_name).rfind("." ARGOS_SHARED_LIBRARY_EXTENSION) +
@@ -246,7 +246,7 @@ namespace argos {
    /****************************************/
 
    void CDynamicLoading::UnloadAllLibraries() {
-      for(TDLHandleMap::iterator it = m_tOpenLibs.begin();
+      for(auto it = m_tOpenLibs.begin();
           it != m_tOpenLibs.end();
           ++it) {
          UnloadLibrary(it->first);

--- a/src/core/utility/profiler/profiler.cpp
+++ b/src/core/utility/profiler/profiler.cpp
@@ -124,7 +124,7 @@ namespace argos {
                          std::ios::app | std::ios::out);
       }
       LOG << "[INFO] Opened file \"" << str_file_name << "\" for profiling." << std::endl;
-      int nError = pthread_mutex_init(&m_tThreadResourceUsageMutex, NULL);
+      int nError = pthread_mutex_init(&m_tThreadResourceUsageMutex, nullptr);
       if(nError) {
          THROW_ARGOSEXCEPTION("Error creating thread profiler mutex " << ::strerror(nError));
       }
@@ -253,14 +253,14 @@ namespace argos {
    /****************************************/
 
    void CProfiler::StartWallClock() {
-      ::gettimeofday(&m_tWallClockStart, NULL);
+      ::gettimeofday(&m_tWallClockStart, nullptr);
    }
 
    /****************************************/
    /****************************************/
 
    void CProfiler::StopWallClock() {
-      ::gettimeofday(&m_tWallClockEnd, NULL);
+      ::gettimeofday(&m_tWallClockEnd, nullptr);
    }
 
    /****************************************/

--- a/src/core/utility/rate.cpp
+++ b/src/core/utility/rate.cpp
@@ -16,7 +16,7 @@ CRate::CRate(Real f_rate) {
 UInt64 CRate::ElapsedUS() const {
   /* Get current time */
   ::timeval tNow;
-  ::gettimeofday(&tNow, NULL);
+  ::gettimeofday(&tNow, nullptr);
   /* Calculate difference between past call and now */
   ::timeval tDiff;
   timersub(&tNow, &m_tPast, &tDiff);
@@ -42,7 +42,7 @@ void CRate::Sleep() {
     ::timespec tSleepPeriod;
     tSleepPeriod.tv_sec = (m_unNominalPeriod - unMicroSecDiff) / 1e6;
     tSleepPeriod.tv_nsec = (m_unNominalPeriod - unMicroSecDiff) * 1000;
-    ::nanosleep(&tSleepPeriod, NULL);
+    ::nanosleep(&tSleepPeriod, nullptr);
   }
   else {
     LOGERR << "[WARNING] Nominal rate "
@@ -53,7 +53,7 @@ void CRate::Sleep() {
 	   << std::endl;
   }
   /* Update past for next call */
-  ::gettimeofday(&m_tPast, NULL);
+  ::gettimeofday(&m_tPast, nullptr);
 }
 
 /****************************************/
@@ -62,7 +62,7 @@ void CRate::Sleep() {
 void CRate::SetRate(Real f_rate) {
   m_fNominalRate = Abs(f_rate);
   m_unNominalPeriod = 1e6 / m_fNominalRate;
-  ::gettimeofday(&m_tPast, NULL);
+  ::gettimeofday(&m_tPast, nullptr);
 }
 
 /****************************************/

--- a/src/core/utility/string_utilities.cpp
+++ b/src/core/utility/string_utilities.cpp
@@ -43,7 +43,7 @@ namespace argos {
    /****************************************/
 
    std::string StringToUpperCase(const std::string& str_string) {
-      char* buf = new char[str_string.length()];
+      auto* buf = new char[str_string.length()];
       str_string.copy(buf, str_string.length());
 
       for(unsigned int i = 0; i < str_string.length(); ++i)
@@ -60,7 +60,7 @@ namespace argos {
    /****************************************/
 
    std::string StringToLowerCase(const std::string& str_string) {
-      char* buf = new char[str_string.length()];
+      auto* buf = new char[str_string.length()];
       str_string.copy(buf, str_string.length());
 
       for(unsigned int i = 0; i < str_string.length(); ++i)
@@ -113,7 +113,7 @@ namespace argos {
       if(::regcomp(&tRegExp, str_pattern.c_str(), REG_EXTENDED | REG_NOSUB) != 0) {
          return false;
       }
-      nStatus = ::regexec(&tRegExp, str_input.c_str(), 0, NULL, 0);
+      nStatus = ::regexec(&tRegExp, str_input.c_str(), 0, nullptr, 0);
       ::regfree(&tRegExp);
       if (nStatus != 0) {
          return false;
@@ -150,7 +150,7 @@ namespace argos {
             /* Get the variable value */
             pchVarValue = ::getenv(strVarName.c_str());
             /* Was the value found? */
-            if(pchVarValue != NULL) {
+            if(pchVarValue != nullptr) {
                /* Yes, it was */
                /* Replace the variable name with its value */
                str_buffer.replace(unStart, strVarName.length()+1, pchVarValue);

--- a/src/plugins/robots/e-puck/simulator/epuck_entity.cpp
+++ b/src/plugins/robots/e-puck/simulator/epuck_entity.cpp
@@ -43,16 +43,16 @@ namespace argos {
    /****************************************/
 
    CEPuckEntity::CEPuckEntity() :
-      CComposableEntity(NULL),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcGroundSensorEquippedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
-      m_pcLightSensorEquippedEntity(NULL),
-      m_pcProximitySensorEquippedEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcWheeledEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcGroundSensorEquippedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
+      m_pcLightSensorEquippedEntity(nullptr),
+      m_pcProximitySensorEquippedEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcWheeledEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
    }
 
    /****************************************/
@@ -65,16 +65,16 @@ namespace argos {
                               Real f_rab_range,
                               size_t un_rab_data_size,
                               const std::string& str_bat_model) :
-      CComposableEntity(NULL, str_id),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcGroundSensorEquippedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
-      m_pcLightSensorEquippedEntity(NULL),
-      m_pcProximitySensorEquippedEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcWheeledEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr, str_id),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcGroundSensorEquippedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
+      m_pcLightSensorEquippedEntity(nullptr),
+      m_pcProximitySensorEquippedEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcWheeledEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
       try {
          /*
           * Create and init components

--- a/src/plugins/robots/e-puck/simulator/epuck_proximity_default_sensor.cpp
+++ b/src/plugins/robots/e-puck/simulator/epuck_proximity_default_sensor.cpp
@@ -22,9 +22,9 @@ namespace argos {
    /****************************************/
 
    CEPuckProximityDefaultSensor::CEPuckProximityDefaultSensor() :
-      m_pcEmbodiedEntity(NULL),
+      m_pcEmbodiedEntity(nullptr),
       m_bShowRays(false),
-      m_pcRNG(NULL),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 

--- a/src/plugins/robots/eye-bot/simulator/eyebot_entity.cpp
+++ b/src/plugins/robots/eye-bot/simulator/eyebot_entity.cpp
@@ -38,16 +38,16 @@ namespace argos {
    /****************************************/
 
    CEyeBotEntity::CEyeBotEntity() :
-      CComposableEntity(NULL),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
-      m_pcLightSensorEquippedEntity(NULL),
-      m_pcPerspectiveCameraEquippedEntity(NULL),
-      m_pcProximitySensorEquippedEntity(NULL),
-      m_pcQuadRotorEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
+      m_pcLightSensorEquippedEntity(nullptr),
+      m_pcPerspectiveCameraEquippedEntity(nullptr),
+      m_pcProximitySensorEquippedEntity(nullptr),
+      m_pcQuadRotorEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
    }
 
    /****************************************/
@@ -63,16 +63,16 @@ namespace argos {
                                 const CRadians& c_perspcam_aperture,
                                 Real f_perspcam_focal_length,
                                 Real f_perspcam_range) :
-      CComposableEntity(NULL, str_id),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
-      m_pcLightSensorEquippedEntity(NULL),
-      m_pcPerspectiveCameraEquippedEntity(NULL),
-      m_pcProximitySensorEquippedEntity(NULL),
-      m_pcQuadRotorEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr, str_id),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
+      m_pcLightSensorEquippedEntity(nullptr),
+      m_pcPerspectiveCameraEquippedEntity(nullptr),
+      m_pcProximitySensorEquippedEntity(nullptr),
+      m_pcQuadRotorEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
       try {
          /*
           * Create and init components

--- a/src/plugins/robots/eye-bot/simulator/eyebot_light_rotzonly_sensor.cpp
+++ b/src/plugins/robots/eye-bot/simulator/eyebot_light_rotzonly_sensor.cpp
@@ -52,9 +52,9 @@ namespace argos {
    /****************************************/
 
    CEyeBotLightRotZOnlySensor::CEyeBotLightRotZOnlySensor() :
-      m_pcEmbodiedEntity(NULL),
+      m_pcEmbodiedEntity(nullptr),
       m_bShowRays(false),
-      m_pcRNG(NULL),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 
@@ -126,7 +126,7 @@ namespace argos {
        *    NOTE: the readings are additive
        * 4. go through the sensors and clamp their values
        */
-      for(CSpace::TMapPerType::iterator it = mapLights.begin();
+      for(auto it = mapLights.begin();
           it != mapLights.end();
           ++it) {
          /* Get a reference to the light */

--- a/src/plugins/robots/foot-bot/simulator/dynamics2d_footbot_model.cpp
+++ b/src/plugins/robots/foot-bot/simulator/dynamics2d_footbot_model.cpp
@@ -51,8 +51,8 @@ namespace argos {
                       FOOTBOT_MAX_TORQUE,
                       FOOTBOT_INTERWHEEL_DISTANCE,
                       c_entity.GetConfigurationNode()),
-      m_pcGripper(NULL),
-      m_pcGrippable(NULL),
+      m_pcGripper(nullptr),
+      m_pcGrippable(nullptr),
       m_fMass(1.6f),
       m_fCurrentWheelVelocity(m_cWheeledEntity.GetWheelVelocities()),
       m_unLastTurretMode(m_cFootBotEntity.GetTurretEntity().GetMode()) {

--- a/src/plugins/robots/foot-bot/simulator/footbot_base_ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_base_ground_rotzonly_sensor.cpp
@@ -23,10 +23,10 @@ namespace argos {
    /****************************************/
 
    CFootBotBaseGroundRotZOnlySensor::CFootBotBaseGroundRotZOnlySensor() :
-      m_pcEmbodiedEntity(NULL),
-      m_pcFloorEntity(NULL),
-      m_pcGroundSensorEntity(NULL),
-      m_pcRNG(NULL),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcFloorEntity(nullptr),
+      m_pcGroundSensorEntity(nullptr),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 

--- a/src/plugins/robots/foot-bot/simulator/footbot_distance_scanner_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_distance_scanner_rotzonly_sensor.cpp
@@ -31,7 +31,7 @@ namespace argos {
    /****************************************/
 
    CFootBotDistanceScannerRotZOnlySensor::CFootBotDistanceScannerRotZOnlySensor() :
-      m_pcRNG(NULL),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()),
       m_bShowRays(false) {}

--- a/src/plugins/robots/foot-bot/simulator/footbot_entity.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_entity.cpp
@@ -57,22 +57,22 @@ namespace argos {
    /****************************************/
 
    CFootBotEntity::CFootBotEntity() :
-      CComposableEntity(NULL),
-      m_pcControllableEntity(NULL),
-      m_pcDistanceScannerEquippedEntity(NULL),
-      m_pcTurretEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcGripperEquippedEntity(NULL),
-      m_pcGroundSensorEquippedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
-      m_pcLightSensorEquippedEntity(NULL),
-      m_pcOmnidirectionalCameraEquippedEntity(NULL),
-      m_pcPerspectiveCameraEquippedEntity(NULL),
-      m_pcProximitySensorEquippedEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcWheeledEntity(NULL),
-      m_pcWiFiEquippedEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr),
+      m_pcControllableEntity(nullptr),
+      m_pcDistanceScannerEquippedEntity(nullptr),
+      m_pcTurretEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcGripperEquippedEntity(nullptr),
+      m_pcGroundSensorEquippedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
+      m_pcLightSensorEquippedEntity(nullptr),
+      m_pcOmnidirectionalCameraEquippedEntity(nullptr),
+      m_pcPerspectiveCameraEquippedEntity(nullptr),
+      m_pcProximitySensorEquippedEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcWheeledEntity(nullptr),
+      m_pcWiFiEquippedEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
    }
 
    /****************************************/
@@ -90,22 +90,22 @@ namespace argos {
                                   const CRadians& c_perspcam_aperture,
                                   Real f_perspcam_focal_length,
                                   Real f_perspcam_range) :
-      CComposableEntity(NULL, str_id),
-      m_pcControllableEntity(NULL),
-      m_pcDistanceScannerEquippedEntity(NULL),
-      m_pcTurretEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcGripperEquippedEntity(NULL),
-      m_pcGroundSensorEquippedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
-      m_pcLightSensorEquippedEntity(NULL),
-      m_pcOmnidirectionalCameraEquippedEntity(NULL),
-      m_pcPerspectiveCameraEquippedEntity(NULL),
-      m_pcProximitySensorEquippedEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcWheeledEntity(NULL),
-      m_pcWiFiEquippedEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr, str_id),
+      m_pcControllableEntity(nullptr),
+      m_pcDistanceScannerEquippedEntity(nullptr),
+      m_pcTurretEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcGripperEquippedEntity(nullptr),
+      m_pcGroundSensorEquippedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
+      m_pcLightSensorEquippedEntity(nullptr),
+      m_pcOmnidirectionalCameraEquippedEntity(nullptr),
+      m_pcPerspectiveCameraEquippedEntity(nullptr),
+      m_pcProximitySensorEquippedEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcWheeledEntity(nullptr),
+      m_pcWiFiEquippedEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
       try {
          /*
           * Create and init components

--- a/src/plugins/robots/foot-bot/simulator/footbot_gripper_default_actuator.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_gripper_default_actuator.cpp
@@ -14,7 +14,7 @@ namespace argos {
    /****************************************/
 
    CFootBotGripperDefaultActuator::CFootBotGripperDefaultActuator() :
-      m_pcGripperEquippedEntity(NULL) {}
+      m_pcGripperEquippedEntity(nullptr) {}
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_light_rotzonly_sensor.cpp
@@ -53,9 +53,9 @@ namespace argos {
 
    CFootBotLightRotZOnlySensor::CFootBotLightRotZOnlySensor() :
       m_bEnabled(true),
-      m_pcEmbodiedEntity(NULL),
+      m_pcEmbodiedEntity(nullptr),
       m_bShowRays(false),
-      m_pcRNG(NULL),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 
@@ -122,7 +122,7 @@ namespace argos {
       /* Buffers to contain data about the intersection */
       SEmbodiedEntityIntersectionItem sIntersection;
       /* List of light entities */
-      CSpace::TMapPerTypePerId::iterator itLights = m_cSpace.GetEntityMapPerTypePerId().find("light");
+      auto itLights = m_cSpace.GetEntityMapPerTypePerId().find("light");
       if (itLights != m_cSpace.GetEntityMapPerTypePerId().end()) {
          CSpace::TMapPerType& mapLights = itLights->second;
          /*
@@ -132,7 +132,7 @@ namespace argos {
        *    NOTE: the readings are additive
        * 4. go through the sensors and clamp their values
        */
-         for(CSpace::TMapPerType::iterator it = mapLights.begin();
+         for(auto it = mapLights.begin();
              it != mapLights.end();
              ++it) {
             /* Get a reference to the light */

--- a/src/plugins/robots/foot-bot/simulator/footbot_motor_ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_motor_ground_rotzonly_sensor.cpp
@@ -23,10 +23,10 @@ namespace argos {
    /****************************************/
 
    CFootBotMotorGroundRotZOnlySensor::CFootBotMotorGroundRotZOnlySensor() :
-      m_pcEmbodiedEntity(NULL),
-      m_pcFloorEntity(NULL),
-      m_pcGroundSensorEntity(NULL),
-      m_pcRNG(NULL),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcFloorEntity(nullptr),
+      m_pcGroundSensorEntity(nullptr),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 

--- a/src/plugins/robots/foot-bot/simulator/footbot_turret_default_actuator.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_turret_default_actuator.cpp
@@ -14,7 +14,7 @@ namespace argos {
    /****************************************/
 
    CFootBotTurretDefaultActuator::CFootBotTurretDefaultActuator() :
-      m_pcTurretEntity(NULL),
+      m_pcTurretEntity(nullptr),
       m_unDesiredMode(CFootBotTurretEntity::MODE_OFF) {}
 
    /****************************************/

--- a/src/plugins/robots/foot-bot/simulator/footbot_turret_encoder_default_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_turret_encoder_default_sensor.cpp
@@ -13,7 +13,7 @@ namespace argos {
    /****************************************/
 
    CFootBotTurretEncoderDefaultSensor::CFootBotTurretEncoderDefaultSensor() :
-      m_pcTurretEntity(NULL) {}
+      m_pcTurretEntity(nullptr) {}
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/foot-bot/simulator/footbot_turret_entity.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_turret_entity.cpp
@@ -16,7 +16,7 @@ namespace argos {
 
    CFootBotTurretEntity::CFootBotTurretEntity(CComposableEntity* pc_parent) :
       CEntity(pc_parent),
-      m_psAnchor(NULL) {
+      m_psAnchor(nullptr) {
       Reset();
       Disable();
    }

--- a/src/plugins/robots/generic/simulator/battery_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/battery_default_sensor.cpp
@@ -22,9 +22,9 @@ namespace argos {
    /****************************************/
 
    CBatteryDefaultSensor::CBatteryDefaultSensor() :
-      m_pcEmbodiedEntity(NULL),
-      m_pcBatteryEntity(NULL),
-      m_pcRNG(NULL),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcBatteryEntity(nullptr),
+      m_pcRNG(nullptr),
       m_bAddNoise(false) {}
 
    /****************************************/

--- a/src/plugins/robots/generic/simulator/camera_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/camera_default_sensor.cpp
@@ -96,7 +96,7 @@ namespace argos {
                CCameraSensorSimulatedAlgorithm* pcAlgorithm = 
                   CFactory<CCameraSensorSimulatedAlgorithm>::New(itAlgorithm->Value());
                /* check that algorithm inherits from a control interface */
-               CCI_CameraSensorAlgorithm* pcCIAlgorithm = 
+               auto* pcCIAlgorithm = 
                   dynamic_cast<CCI_CameraSensorAlgorithm*>(pcAlgorithm);
                if(pcCIAlgorithm == nullptr) {
                   THROW_ARGOSEXCEPTION("Algorithm \"" << itAlgorithm->Value() << 

--- a/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/colored_blob_omnidirectional_camera_rotzonly_sensor.cpp
@@ -29,7 +29,7 @@ namespace argos {
          m_cControllableEntity(c_controllable_entity),
          m_bShowRays(b_show_rays),
          m_fDistanceNoiseStdDev(f_noise_std_dev),
-         m_pcRNG(NULL) {
+         m_pcRNG(nullptr) {
          m_pcRootSensingEntity = &m_cEmbodiedEntity.GetParent();
          if(m_fDistanceNoiseStdDev > 0.0f) {
             m_pcRNG = CRandom::CreateRNG("argos");
@@ -121,11 +121,11 @@ namespace argos {
 
    CColoredBlobOmnidirectionalCameraRotZOnlySensor::CColoredBlobOmnidirectionalCameraRotZOnlySensor() :
       m_bEnabled(false),
-      m_pcOmnicamEntity(NULL),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcLEDIndex(NULL),
-      m_pcEmbodiedIndex(NULL),
+      m_pcOmnicamEntity(nullptr),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcLEDIndex(nullptr),
+      m_pcEmbodiedIndex(nullptr),
       m_bShowRays(false) {
    }
 

--- a/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/colored_blob_perspective_camera_default_sensor.cpp
@@ -29,7 +29,7 @@ namespace argos {
          m_cControllableEntity(c_controllable_entity),
          m_bShowRays(b_show_rays),
          m_fNoiseStdDev(f_noise_std_dev),
-         m_pcRNG(NULL) {
+         m_pcRNG(nullptr) {
          m_pcRootSensingEntity = &m_cEmbodiedEntity.GetRootEntity();
          if(m_fNoiseStdDev > 0.0f) {
             m_pcRNG = CRandom::CreateRNG("argos");
@@ -140,11 +140,11 @@ namespace argos {
 
    CColoredBlobPerspectiveCameraDefaultSensor::CColoredBlobPerspectiveCameraDefaultSensor() :
       m_bEnabled(false),
-      m_pcCamEntity(NULL),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcLEDIndex(NULL),
-      m_pcEmbodiedIndex(NULL),
+      m_pcCamEntity(nullptr),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcLEDIndex(nullptr),
+      m_pcEmbodiedIndex(nullptr),
       m_bShowRays(false) {
    }
 

--- a/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/differential_steering_default_actuator.cpp
@@ -14,8 +14,8 @@ namespace argos {
    /****************************************/
 
    CDifferentialSteeringDefaultActuator::CDifferentialSteeringDefaultActuator() :
-      m_pcWheeledEntity(NULL),
-      m_pcRNG(NULL) {
+      m_pcWheeledEntity(nullptr),
+      m_pcRNG(nullptr) {
       m_fCurrentVelocity[LEFT_WHEEL] = 0.0;
       m_fCurrentVelocity[RIGHT_WHEEL] = 0.0;
       m_fNoiseBias[LEFT_WHEEL] = 1.0;

--- a/src/plugins/robots/generic/simulator/differential_steering_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/differential_steering_default_sensor.cpp
@@ -16,8 +16,8 @@ namespace argos {
    /****************************************/
 
    CDifferentialSteeringDefaultSensor::CDifferentialSteeringDefaultSensor() :
-      m_pcWheeledEntity(NULL),
-      m_pcRNG(NULL),
+      m_pcWheeledEntity(nullptr),
+      m_pcRNG(nullptr),
       m_bAddNoise(false) {}
 
    /****************************************/

--- a/src/plugins/robots/generic/simulator/gripper_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/gripper_default_actuator.cpp
@@ -14,7 +14,7 @@ namespace argos {
    /****************************************/
 
    CGripperDefaultActuator::CGripperDefaultActuator() :
-      m_pcGripperEquippedEntity(NULL) {}
+      m_pcGripperEquippedEntity(nullptr) {}
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/ground_rotzonly_sensor.cpp
@@ -23,10 +23,10 @@ namespace argos {
    /****************************************/
 
    CGroundRotZOnlySensor::CGroundRotZOnlySensor() :
-      m_pcEmbodiedEntity(NULL),
-      m_pcFloorEntity(NULL),
-      m_pcGroundSensorEntity(NULL),
-      m_pcRNG(NULL),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcFloorEntity(nullptr),
+      m_pcGroundSensorEntity(nullptr),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 

--- a/src/plugins/robots/generic/simulator/leds_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/leds_default_actuator.cpp
@@ -15,7 +15,7 @@ namespace argos {
    /****************************************/
 
    CLEDsDefaultActuator::CLEDsDefaultActuator() :
-      m_pcLEDEquippedEntity(NULL) {}
+      m_pcLEDEquippedEntity(nullptr) {}
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/generic/simulator/light_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/light_default_sensor.cpp
@@ -24,7 +24,7 @@ namespace argos {
 
    CLightDefaultSensor::CLightDefaultSensor() :
       m_bShowRays(false),
-      m_pcRNG(NULL),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 
@@ -81,7 +81,7 @@ namespace argos {
       /* Buffers to contain data about the intersection */
       SEmbodiedEntityIntersectionItem sIntersection;
       /* Get the map of light entities */
-      CSpace::TMapPerTypePerId::iterator itLights = m_cSpace.GetEntityMapPerTypePerId().find("light");
+      auto itLights = m_cSpace.GetEntityMapPerTypePerId().find("light");
       if (itLights != m_cSpace.GetEntityMapPerTypePerId().end()) {
          CSpace::TMapPerType& mapLights = itLights->second;
          /* Go through the sensors */
@@ -91,7 +91,7 @@ namespace argos {
             cRayStart.Rotate(m_pcLightEntity->GetSensor(i).Anchor.Orientation);
             cRayStart += m_pcLightEntity->GetSensor(i).Anchor.Position;
             /* Go through all the light entities */
-            for(CSpace::TMapPerType::iterator it = mapLights.begin();
+            for(auto it = mapLights.begin();
                 it != mapLights.end();
                 ++it) {
                /* Get a reference to the light */

--- a/src/plugins/robots/generic/simulator/positioning_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/positioning_default_sensor.cpp
@@ -16,8 +16,8 @@ namespace argos {
    /****************************************/
 
    CPositioningDefaultSensor::CPositioningDefaultSensor() :
-      m_pcEmbodiedEntity(NULL),
-      m_pcRNG(NULL),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcRNG(nullptr),
       m_bAddNoise(false) {}
 
    /****************************************/

--- a/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/proximity_default_sensor.cpp
@@ -22,9 +22,9 @@ namespace argos {
    /****************************************/
 
    CProximityDefaultSensor::CProximityDefaultSensor() :
-      m_pcEmbodiedEntity(NULL),
+      m_pcEmbodiedEntity(nullptr),
       m_bShowRays(false),
-      m_pcRNG(NULL),
+      m_pcRNG(nullptr),
       m_bAddNoise(false),
       m_cSpace(CSimulator::GetInstance().GetSpace()) {}
 

--- a/src/plugins/robots/generic/simulator/quadrotor_position_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/quadrotor_position_default_actuator.cpp
@@ -13,7 +13,7 @@ namespace argos {
    /****************************************/
 
    CQuadRotorPositionDefaultActuator::CQuadRotorPositionDefaultActuator() :
-      m_pcQuadRotorEntity(NULL) {
+      m_pcQuadRotorEntity(nullptr) {
    }
 
    /****************************************/

--- a/src/plugins/robots/generic/simulator/quadrotor_speed_default_actuator.cpp
+++ b/src/plugins/robots/generic/simulator/quadrotor_speed_default_actuator.cpp
@@ -13,7 +13,7 @@ namespace argos {
    /****************************************/
 
    CQuadRotorSpeedDefaultActuator::CQuadRotorSpeedDefaultActuator() :
-      m_pcQuadRotorEntity(NULL) {
+      m_pcQuadRotorEntity(nullptr) {
    }
 
    /****************************************/

--- a/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.cpp
+++ b/src/plugins/robots/generic/simulator/range_and_bearing_medium_sensor.cpp
@@ -22,10 +22,10 @@ namespace argos {
    /****************************************/
 
    CRangeAndBearingMediumSensor::CRangeAndBearingMediumSensor() :
-      m_pcRangeAndBearingEquippedEntity(NULL),
+      m_pcRangeAndBearingEquippedEntity(nullptr),
       m_fDistanceNoiseStdDev(0.0f),
       m_fPacketDropProb(0.0f),
-      m_pcRNG(NULL),
+      m_pcRNG(nullptr),
       m_cSpace(CSimulator::GetInstance().GetSpace()),
       m_bShowRays(false) {}
 
@@ -86,7 +86,7 @@ namespace argos {
       for(CSet<CRABEquippedEntity*>::iterator it = setRABs.begin();
           it != setRABs.end(); ++it) {
          /* Should we drop this packet? */
-         if(m_pcRNG == NULL || /* No noise to apply */
+         if(m_pcRNG == nullptr || /* No noise to apply */
             !(m_fPacketDropProb > 0.0f &&
               m_pcRNG->Bernoulli(m_fPacketDropProb)) /* Packet is not dropped */
             ) {

--- a/src/plugins/robots/prototype/simulator/dynamics3d_prototype_model.cpp
+++ b/src/plugins/robots/prototype/simulator/dynamics3d_prototype_model.cpp
@@ -129,7 +129,7 @@ namespace argos {
       /* While there are joints to be added */
       while(! vecJointsToAdd.empty()) {
          size_t unRemainingJoints = vecJointsToAdd.size();
-         for(CPrototypeJointEntity::TVectorIterator it_joint = std::begin(vecJointsToAdd);
+         for(auto it_joint = std::begin(vecJointsToAdd);
              it_joint != std::end(vecJointsToAdd);
              ++it_joint) {
             /* Get a reference to the joint */
@@ -137,7 +137,7 @@ namespace argos {
             /* Get a reference to the parent link entity */
             const CPrototypeLinkEntity& cParentLink = cJoint.GetParentLink();
             /* Check if the parent link has been added */
-            CAbstractBody::TVectorIterator itParentLinkBody =
+            auto itParentLinkBody =
                std::find_if(std::begin(m_vecBodies),
                             std::end(m_vecBodies),
                             [&cParentLink] (const std::shared_ptr<CAbstractBody>& ptr_body) {

--- a/src/plugins/robots/prototype/simulator/prototype_entity.cpp
+++ b/src/plugins/robots/prototype/simulator/prototype_entity.cpp
@@ -81,7 +81,7 @@ namespace argos {
                   /* Add the directional LEDs to the medium */
                   std::string strMedium;
                   GetNodeAttribute(*itDevice, "medium", strMedium);
-                  CDirectionalLEDMedium& cDirectionalLEDMedium = 
+                  auto& cDirectionalLEDMedium = 
                      CSimulator::GetInstance().GetMedium<CDirectionalLEDMedium>(strMedium);
                   m_pcDirectionalLEDEquippedEntity->SetMedium(cDirectionalLEDMedium);
                   m_pcDirectionalLEDEquippedEntity->Enable();
@@ -93,7 +93,7 @@ namespace argos {
                   /* Add the LEDs to the medium */
                   std::string strMedium;
                   GetNodeAttribute(*itDevice, "medium", strMedium);
-                  CLEDMedium& cLEDMedium = 
+                  auto& cLEDMedium = 
                      CSimulator::GetInstance().GetMedium<CLEDMedium>(strMedium);
                   m_pcLEDEquippedEntity->SetMedium(cLEDMedium);
                   m_pcLEDEquippedEntity->Enable();
@@ -111,20 +111,20 @@ namespace argos {
                   /* Add the tags to the medium */
                   std::string strMedium;
                   GetNodeAttribute(*itDevice, "medium", strMedium);
-                  CTagMedium& cTagMedium = 
+                  auto& cTagMedium = 
                      CSimulator::GetInstance().GetMedium<CTagMedium>(strMedium);
                   m_pcTagEquippedEntity->SetMedium(cTagMedium);
                   m_pcTagEquippedEntity->Enable();
                }
                else if(itDevice->Value() == "radios" ) {
-                  CRadioEquippedEntity* m_pcRadioEquippedEntity =
+                  auto* m_pcRadioEquippedEntity =
                      new CRadioEquippedEntity(this);
                   m_pcRadioEquippedEntity->Init(*itDevice);
                   AddComponent(*m_pcRadioEquippedEntity);
                   /* Add the radios to the medium */
                   std::string strMedium;
                   GetNodeAttribute(*itDevice, "medium", strMedium);
-                  CRadioMedium& cRadioMedium = 
+                  auto& cRadioMedium = 
                      CSimulator::GetInstance().GetMedium<CRadioMedium>(strMedium);
                   m_pcRadioEquippedEntity->SetMedium(cRadioMedium);
                   m_pcRadioEquippedEntity->Enable();

--- a/src/plugins/robots/prototype/simulator/prototype_joint_entity.cpp
+++ b/src/plugins/robots/prototype/simulator/prototype_joint_entity.cpp
@@ -33,7 +33,7 @@ namespace argos {
          /* Init parent */
          CComposableEntity::Init(t_tree);
          /* Get parent and child links */
-         CPrototypeLinkEquippedEntity& cLinkEquippedEntity = 
+         auto& cLinkEquippedEntity = 
             GetParent().GetParent().GetComponent<CPrototypeLinkEquippedEntity>("links");
          /* Get the disable collisions with parent flag */
          GetNodeAttributeOrDefault(t_tree,

--- a/src/plugins/robots/prototype/simulator/prototype_joint_equipped_entity.cpp
+++ b/src/plugins/robots/prototype/simulator/prototype_joint_equipped_entity.cpp
@@ -27,7 +27,7 @@ namespace argos {
              itJoint != itJoint.end();
              ++itJoint) {
             /* for each <joint/> node */
-            CPrototypeJointEntity* pcJointEntity = new CPrototypeJointEntity(this);
+            auto* pcJointEntity = new CPrototypeJointEntity(this);
             pcJointEntity->Init(*itJoint);
             AddComponent(*pcJointEntity);
             m_vecJoints.push_back(pcJointEntity);
@@ -42,7 +42,7 @@ namespace argos {
    /****************************************/
 
    CPrototypeJointEntity& CPrototypeJointEquippedEntity::GetJoint(const std::string& str_id) {
-      CPrototypeJointEntity::TVectorIterator itJoint =
+      auto itJoint =
          std::find_if(std::begin(m_vecJoints),
                       std::end(m_vecJoints),
                       [str_id] (const CPrototypeJointEntity* pc_joint) {

--- a/src/plugins/robots/prototype/simulator/prototype_link_entity.cpp
+++ b/src/plugins/robots/prototype/simulator/prototype_link_entity.cpp
@@ -80,7 +80,7 @@ namespace argos {
          CQuaternion cOffsetOrientation;
          GetNodeAttributeOrDefault(t_tree, "orientation", cOffsetOrientation, cOffsetOrientation);
          /* Create an anchor for this link */
-         CEmbodiedEntity& cBody = GetParent().GetParent().GetComponent<CEmbodiedEntity>("body");
+         auto& cBody = GetParent().GetParent().GetComponent<CEmbodiedEntity>("body");
          m_psAnchor = &(cBody.AddAnchor(GetId(), cOffsetPosition, cOffsetOrientation));
          /* Enable the anchor */
          m_psAnchor->Enable();

--- a/src/plugins/robots/prototype/simulator/prototype_link_equipped_entity.cpp
+++ b/src/plugins/robots/prototype/simulator/prototype_link_equipped_entity.cpp
@@ -26,7 +26,7 @@ namespace argos {
          for(itLink = itLink.begin(&t_tree);
              itLink != itLink.end();
              ++itLink) {
-            CPrototypeLinkEntity* pcLinkEntity = new CPrototypeLinkEntity(this);
+            auto* pcLinkEntity = new CPrototypeLinkEntity(this);
             pcLinkEntity->Init(*itLink);
             AddComponent(*pcLinkEntity);            
             m_vecLinks.push_back(pcLinkEntity);
@@ -34,7 +34,7 @@ namespace argos {
          /* Get the reference link */
          std::string strReferenceLink;
          GetNodeAttribute(t_tree, "ref", strReferenceLink);
-         CPrototypeLinkEntity::TVectorIterator itReferenceLink =
+         auto itReferenceLink =
             std::find_if(std::begin(m_vecLinks),
                          std::end(m_vecLinks),
                          [strReferenceLink] (const CPrototypeLinkEntity* pc_link) {
@@ -61,7 +61,7 @@ namespace argos {
    /****************************************/
 
    CPrototypeLinkEntity& CPrototypeLinkEquippedEntity::GetLink(const std::string& str_id) {
-      CPrototypeLinkEntity::TVectorIterator itLink =
+      auto itLink =
          std::find_if(std::begin(m_vecLinks),
                       std::end(m_vecLinks),
                       [str_id] (const CPrototypeLinkEntity* pc_link) {

--- a/src/plugins/robots/spiri/simulator/spiri_entity.cpp
+++ b/src/plugins/robots/spiri/simulator/spiri_entity.cpp
@@ -34,13 +34,13 @@ namespace argos {
    /****************************************/
 
    CSpiriEntity::CSpiriEntity() :
-      CComposableEntity(NULL),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcQuadRotorEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcPerspectiveCameraEquippedEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcQuadRotorEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcPerspectiveCameraEquippedEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
    }
 
    /****************************************/
@@ -55,13 +55,13 @@ namespace argos {
                               const std::string& str_bat_model,
                               const CRadians& c_cam_aperture,
                               Real f_cam_range) :
-      CComposableEntity(NULL, str_id),
-      m_pcControllableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcQuadRotorEntity(NULL),
-      m_pcRABEquippedEntity(NULL),
-      m_pcPerspectiveCameraEquippedEntity(NULL),
-      m_pcBatteryEquippedEntity(NULL) {
+      CComposableEntity(nullptr, str_id),
+      m_pcControllableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcQuadRotorEntity(nullptr),
+      m_pcRABEquippedEntity(nullptr),
+      m_pcPerspectiveCameraEquippedEntity(nullptr),
+      m_pcBatteryEquippedEntity(nullptr) {
       try {
          /*
           * Create and init components

--- a/src/plugins/simulator/entities/battery_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/battery_equipped_entity.cpp
@@ -17,7 +17,7 @@ namespace argos {
       CEntity(pc_parent),
       m_fFullCharge(1.0),
       m_fAvailableCharge(m_fFullCharge),
-      m_pcDischargeModel(NULL) {
+      m_pcDischargeModel(nullptr) {
       SetDischargeModel(new CBatteryDischargeModelTime());
       Disable();
    }
@@ -33,7 +33,7 @@ namespace argos {
       CEntity(pc_parent, str_id),
       m_fFullCharge(f_full_charge),
       m_fAvailableCharge(f_start_charge),
-      m_pcDischargeModel(NULL) {
+      m_pcDischargeModel(nullptr) {
       SetDischargeModel(pc_discharge_model);
       Disable();
    }
@@ -49,7 +49,7 @@ namespace argos {
       CEntity(pc_parent, str_id),
       m_fFullCharge(f_full_charge),
       m_fAvailableCharge(f_start_charge),
-      m_pcDischargeModel(NULL) {
+      m_pcDischargeModel(nullptr) {
       SetDischargeModel(str_discharge_model);
       Disable();
    }
@@ -119,7 +119,7 @@ namespace argos {
    /****************************************/
 
    CBatteryDischargeModel::CBatteryDischargeModel() :
-      m_pcBattery(NULL) {
+      m_pcBattery(nullptr) {
    }
 
    /****************************************/
@@ -170,9 +170,9 @@ namespace argos {
          CBatteryDischargeModel::SetBattery(pc_battery);
          /* Get a hold of the body and anchor of the entity that contains the battery */
          CEntity* pcRoot = &pc_battery->GetRootEntity();
-         CComposableEntity* cComp = dynamic_cast<CComposableEntity*>(pcRoot);
-         if(cComp != NULL) {
-            CEmbodiedEntity& cBody = cComp->GetComponent<CEmbodiedEntity>("body");
+         auto* cComp = dynamic_cast<CComposableEntity*>(pcRoot);
+         if(cComp != nullptr) {
+            auto& cBody = cComp->GetComponent<CEmbodiedEntity>("body");
             m_psAnchor = &cBody.GetOriginAnchor();
             m_cOldPosition = m_psAnchor->Position;
          }
@@ -232,9 +232,9 @@ namespace argos {
          CBatteryDischargeModel::SetBattery(pc_battery);
          /* Get a hold of the body and anchor of the entity that contains the battery */
          CEntity* pcRoot = &pc_battery->GetRootEntity();
-         CComposableEntity* cComp = dynamic_cast<CComposableEntity*>(pcRoot);
-         if(cComp != NULL) {
-            CEmbodiedEntity& cBody = cComp->GetComponent<CEmbodiedEntity>("body");
+         auto* cComp = dynamic_cast<CComposableEntity*>(pcRoot);
+         if(cComp != nullptr) {
+            auto& cBody = cComp->GetComponent<CEmbodiedEntity>("body");
             m_psAnchor = &cBody.GetOriginAnchor();
             m_cOldPosition = m_psAnchor->Position;
          }

--- a/src/plugins/simulator/entities/box_entity.cpp
+++ b/src/plugins/simulator/entities/box_entity.cpp
@@ -16,11 +16,11 @@ namespace argos {
    /****************************************/
 
    CBoxEntity::CBoxEntity():
-      CComposableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
+      CComposableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
       m_fMass(1.0f),
-      m_pcLEDMedium(NULL) {}
+      m_pcLEDMedium(nullptr) {}
 
    /****************************************/
    /****************************************/
@@ -31,7 +31,7 @@ namespace argos {
                           bool b_movable,
                           const CVector3& c_size,
                           Real f_mass) :
-      CComposableEntity(NULL, str_id),
+      CComposableEntity(nullptr, str_id),
       m_pcEmbodiedEntity(
          new CEmbodiedEntity(this,
                              "body_0",

--- a/src/plugins/simulator/entities/cylinder_entity.cpp
+++ b/src/plugins/simulator/entities/cylinder_entity.cpp
@@ -16,11 +16,11 @@ namespace argos {
    /****************************************/
 
    CCylinderEntity::CCylinderEntity() :
-      CComposableEntity(NULL),
-      m_pcEmbodiedEntity(NULL),
-      m_pcLEDEquippedEntity(NULL),
+      CComposableEntity(nullptr),
+      m_pcEmbodiedEntity(nullptr),
+      m_pcLEDEquippedEntity(nullptr),
       m_fMass(1.0f),
-      m_pcLEDMedium(NULL) {
+      m_pcLEDMedium(nullptr) {
    }
 
    /****************************************/
@@ -33,7 +33,7 @@ namespace argos {
                                     Real f_radius,
                                     Real f_height,
                                     Real f_mass) :
-      CComposableEntity(NULL, str_id),
+      CComposableEntity(nullptr, str_id),
       m_pcEmbodiedEntity(
          new CEmbodiedEntity(this,
                              "body_0",

--- a/src/plugins/simulator/entities/directional_led_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/directional_led_equipped_entity.cpp
@@ -53,7 +53,7 @@ namespace argos {
              itLED != itLED.end();
              ++itLED) {
             /* Initialise the LED using the XML */
-            CDirectionalLEDEntity* pcLED = new CDirectionalLEDEntity(this);
+            auto* pcLED = new CDirectionalLEDEntity(this);
             pcLED->Init(*itLED);
             CVector3 cPositionOffset;
             GetNodeAttribute(*itLED, "position", cPositionOffset);
@@ -70,7 +70,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody =
+            auto& cBody =
                GetParent().GetComponent<CEmbodiedEntity>("body");
             /* Add the LED to this container */
             m_vecInstances.emplace_back(*pcLED,
@@ -97,7 +97,7 @@ namespace argos {
                                               const CRadians& c_observable_angle,
                                               const CColor& c_color) {
       /* create the new directional LED entity */
-      CDirectionalLEDEntity* pcLED =
+      auto* pcLED =
          new CDirectionalLEDEntity(this,
                                    str_id,
                                    c_position,

--- a/src/plugins/simulator/entities/gripper_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/gripper_equipped_entity.cpp
@@ -21,7 +21,7 @@ namespace argos {
       CEntity(pc_parent),
       m_fLockState(0.0f),
       m_fLockThreshold(0.5f),
-      m_pcGrippedEntity(NULL) {
+      m_pcGrippedEntity(nullptr) {
       Disable();
    }
          
@@ -41,7 +41,7 @@ namespace argos {
       m_cInitDirection(c_direction),
       m_fLockState(0.0f),
       m_fLockThreshold(f_lock_threshold),
-      m_pcGrippedEntity(NULL) {
+      m_pcGrippedEntity(nullptr) {
       Disable();
    }
          
@@ -94,7 +94,7 @@ namespace argos {
    /****************************************/
          
    CEmbodiedEntity& CGripperEquippedEntity::GetGrippedEntity() {
-      if(m_pcGrippedEntity != NULL) {
+      if(m_pcGrippedEntity != nullptr) {
          return *m_pcGrippedEntity;
       }
       else {

--- a/src/plugins/simulator/entities/ground_sensor_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/ground_sensor_equipped_entity.cpp
@@ -66,7 +66,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+            auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
             if(it->Value() == "sensor") {
                CVector2 cOffset;
                GetNodeAttribute(*it, "offset", cOffset);

--- a/src/plugins/simulator/entities/led_entity.cpp
+++ b/src/plugins/simulator/entities/led_entity.cpp
@@ -16,7 +16,7 @@ namespace argos {
 
    CLEDEntity::CLEDEntity(CComposableEntity* pc_parent) :
       CPositionalEntity(pc_parent),
-      m_pcMedium(NULL) {
+      m_pcMedium(nullptr) {
       Disable();
    }
 
@@ -30,7 +30,7 @@ namespace argos {
       CPositionalEntity(pc_parent, str_id, c_position, CQuaternion()),
       m_cColor(c_color),
       m_cInitColor(c_color),
-      m_pcMedium(NULL) {
+      m_pcMedium(nullptr) {
       SetColor(c_color);
    }
 
@@ -92,7 +92,7 @@ namespace argos {
    /****************************************/
 
    CLEDMedium& CLEDEntity::GetMedium() const {
-      if(m_pcMedium == NULL) {
+      if(m_pcMedium == nullptr) {
          THROW_ARGOSEXCEPTION("LED entity \"" << GetContext() << GetId() << "\" has no medium associated.");
       }
       return *m_pcMedium;
@@ -102,7 +102,7 @@ namespace argos {
    /****************************************/
 
    void CLEDEntity::SetMedium(CLEDMedium& c_medium) {
-      if(m_pcMedium != NULL && m_pcMedium != &c_medium)
+      if(m_pcMedium != nullptr && m_pcMedium != &c_medium)
          m_pcMedium->RemoveEntity(*this);
       m_pcMedium = &c_medium;
    }

--- a/src/plugins/simulator/entities/led_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/led_equipped_entity.cpp
@@ -63,7 +63,7 @@ namespace argos {
              itLED != itLED.end();
              ++itLED) {
             /* Initialise the LED using the XML */
-            CLEDEntity* pcLED = new CLEDEntity(this);
+            auto* pcLED = new CLEDEntity(this);
             pcLED->Init(*itLED);
             /* Parse the offset */
             CVector3 cOffset;
@@ -79,7 +79,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+            auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
             /* Add the LED to this container */
             m_tLEDs.push_back(new SActuator(*pcLED, cOffset, cBody.GetAnchor(strAnchorId)));
             AddComponent(*pcLED);
@@ -95,7 +95,7 @@ namespace argos {
    /****************************************/
 
    void CLEDEquippedEntity::Reset() {
-      for(SActuator::TList::iterator it = m_tLEDs.begin();
+      for(auto it = m_tLEDs.begin();
           it != m_tLEDs.end();
           ++it) {
          (*it)->LED.Reset();

--- a/src/plugins/simulator/entities/light_entity.cpp
+++ b/src/plugins/simulator/entities/light_entity.cpp
@@ -15,7 +15,7 @@ namespace argos {
    /****************************************/
 
    CLightEntity::CLightEntity() :
-      CLEDEntity(NULL),
+      CLEDEntity(nullptr),
       m_fIntensity(1.0f) {}
       
    /****************************************/
@@ -25,7 +25,7 @@ namespace argos {
                               const CVector3& c_position,
                               const CColor& c_color,
                               Real f_intensity) :
-      CLEDEntity(NULL,
+      CLEDEntity(nullptr,
                  str_id,
                  c_position,
                  c_color),
@@ -42,7 +42,7 @@ namespace argos {
          GetNodeAttribute(t_tree, "intensity", m_fIntensity);
          std::string strMedium;
          GetNodeAttribute(t_tree, "medium", strMedium);
-         CLEDMedium& cLEDMedium = CSimulator::GetInstance().GetMedium<CLEDMedium>(strMedium);
+         auto& cLEDMedium = CSimulator::GetInstance().GetMedium<CLEDMedium>(strMedium);
          cLEDMedium.AddEntity(*this);
       }
       catch(CARGoSException& ex) {

--- a/src/plugins/simulator/entities/light_sensor_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/light_sensor_equipped_entity.cpp
@@ -80,7 +80,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+            auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
             if(it->Value() == "sensor") {
                CVector3 cPos, cDir;
                Real fRange;

--- a/src/plugins/simulator/entities/magnet_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/magnet_equipped_entity.cpp
@@ -48,7 +48,7 @@ namespace argos {
              itMagnet != itMagnet.end();
              ++itMagnet) {
             /* Initialise the Magnet using the XML */
-            CMagnetEntity* pcMagnet = new CMagnetEntity(this);
+            auto* pcMagnet = new CMagnetEntity(this);
             pcMagnet->Init(*itMagnet);
             CVector3 cOffset;
             GetNodeAttribute(*itMagnet, "offset", cOffset);
@@ -63,7 +63,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+            auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
             /* Add the magnet to this container */
             m_vecInstances.emplace_back(*pcMagnet,
                                         cBody.GetAnchor(strAnchorId),
@@ -119,7 +119,7 @@ namespace argos {
                                                    const CVector3& c_position_offset,
                                                    const CVector3& c_passive_field,
                                                    const CVector3& c_active_field) {
-      CMagnetEntity* pcMagnet = new CMagnetEntity(this, str_id, c_passive_field, c_active_field);
+      auto* pcMagnet = new CMagnetEntity(this, str_id, c_passive_field, c_active_field);
       m_vecInstances.emplace_back(*pcMagnet, s_anchor, c_position_offset);
       AddComponent(*pcMagnet);
       return *pcMagnet;

--- a/src/plugins/simulator/entities/perspective_camera_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/perspective_camera_equipped_entity.cpp
@@ -13,7 +13,7 @@ namespace argos {
       m_fRange(0.0f),
       m_nImagePxWidth(0),
       m_nImagePxHeight(0),
-      m_psAnchor(NULL) {
+      m_psAnchor(nullptr) {
       Disable();
    }
 
@@ -61,7 +61,7 @@ namespace argos {
           * 3. the "body" is an embodied entity
           * If any of the above is false, this line will bomb out.
           */
-         CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+         auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
          m_psAnchor = &cBody.GetAnchor(strAnchorId);
       }
       catch(CARGoSException& ex) {

--- a/src/plugins/simulator/entities/proximity_sensor_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/proximity_sensor_equipped_entity.cpp
@@ -80,7 +80,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+            auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
             if(it->Value() == "sensor") {
                CVector3 cOff, cDir;
                Real fRange;

--- a/src/plugins/simulator/entities/rab_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/rab_equipped_entity.cpp
@@ -19,10 +19,10 @@ namespace argos {
 
    CRABEquippedEntity::CRABEquippedEntity(CComposableEntity* pc_parent) :
       CPositionalEntity(pc_parent),
-      m_psAnchor(NULL),
+      m_psAnchor(nullptr),
       m_fRange(0.0f),
-      m_pcEntityBody(NULL),
-      m_pcMedium(NULL) {
+      m_pcEntityBody(nullptr),
+      m_pcMedium(nullptr) {
       Disable();
    }
 
@@ -45,7 +45,7 @@ namespace argos {
       m_cData(un_msg_size),
       m_fRange(f_range),
       m_pcEntityBody(&c_entity_body),
-      m_pcMedium(NULL) {
+      m_pcMedium(nullptr) {
       Disable();
       CVector3 cPos = c_pos_offset;
       cPos.Rotate(s_anchor.Orientation);

--- a/src/plugins/simulator/entities/radio_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/radio_equipped_entity.cpp
@@ -51,7 +51,7 @@ namespace argos {
              itRadio != itRadio.end();
              ++itRadio) {
             /* Initialise the radio using the XML */
-            CRadioEntity* pcRadio = new CRadioEntity(this);
+            auto* pcRadio = new CRadioEntity(this);
             pcRadio->Init(*itRadio);
             CVector3 cOffset;
             GetNodeAttribute(*itRadio, "position", cOffset);
@@ -66,7 +66,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+            auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
             /* Add the radio to this container */
             m_vecInstances.emplace_back(*pcRadio, cBody.GetAnchor(strAnchorId), cOffset);
             AddComponent(*pcRadio);
@@ -111,7 +111,7 @@ namespace argos {
                                        SAnchor& s_anchor,
                                        Real f_transmit_range) {
       /* create the new radio entity */
-      CRadioEntity* pcRadio =
+      auto* pcRadio =
          new CRadioEntity(this,
                           str_id,
                           f_transmit_range);

--- a/src/plugins/simulator/entities/tag_equipped_entity.cpp
+++ b/src/plugins/simulator/entities/tag_equipped_entity.cpp
@@ -53,7 +53,7 @@ namespace argos {
              itTag != itTag.end();
              ++itTag) {
             /* Initialise the Tag using the XML */
-            CTagEntity* pcTag = new CTagEntity(this);
+            auto* pcTag = new CTagEntity(this);
             pcTag->Init(*itTag);
             CVector3 cPositionOffset;
             GetNodeAttribute(*itTag, "position", cPositionOffset);
@@ -70,7 +70,7 @@ namespace argos {
              * 3. the "body" is an embodied entity
              * If any of the above is false, this line will bomb out.
              */
-            CEmbodiedEntity& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
+            auto& cBody = GetParent().GetComponent<CEmbodiedEntity>("body");
             /* Add the tag to this container */
             m_vecInstances.emplace_back(*pcTag,
                                         cBody.GetAnchor(strAnchorId),
@@ -121,7 +121,7 @@ namespace argos {
                                    Real f_side_length,
                                    const std::string& str_payload) {
       /* create the new tag entity */
-      CTagEntity* pcTag =
+      auto* pcTag =
          new CTagEntity(this,
                         str_id,
                         c_position,

--- a/src/plugins/simulator/media/led_medium.cpp
+++ b/src/plugins/simulator/media/led_medium.cpp
@@ -82,7 +82,7 @@ namespace argos {
 
    void CLEDMedium::Destroy() {
       delete m_pcLEDEntityIndex;
-      if(m_pcLEDEntityGridUpdateOperation != NULL) {
+      if(m_pcLEDEntityGridUpdateOperation != nullptr) {
          delete m_pcLEDEntityGridUpdateOperation;
       }
    }

--- a/src/plugins/simulator/media/rab_medium.cpp
+++ b/src/plugins/simulator/media/rab_medium.cpp
@@ -93,7 +93,7 @@ namespace argos {
 
    void CRABMedium::Destroy() {
       delete m_pcRABEquippedEntityIndex;
-      if(m_pcRABEquippedEntityGridUpdateOperation != NULL) {
+      if(m_pcRABEquippedEntityGridUpdateOperation != nullptr) {
          delete m_pcRABEquippedEntityGridUpdateOperation;
       }
    }

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_engine.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_engine.cpp
@@ -23,8 +23,8 @@ namespace argos {
       m_fBoxAngularFriction(1.49),
       m_fCylinderLinearFriction(1.49),
       m_fCylinderAngularFriction(1.49),
-      m_ptSpace(NULL),
-      m_ptGroundBody(NULL),
+      m_ptSpace(nullptr),
+      m_ptGroundBody(nullptr),
       m_fElevation(0.0f) {
    }
 
@@ -76,9 +76,9 @@ namespace argos {
             SHAPE_GRIPPABLE,
             BeginCollisionBetweenGripperAndGrippable,
             ManageCollisionBetweenGripperAndGrippable,
-            NULL,
-            NULL,
-            NULL);
+            nullptr,
+            nullptr,
+            nullptr);
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Error initializing the dynamics 2D engine \"" << GetId() << "\"", ex);
@@ -89,7 +89,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics2DEngine::Reset() {
-      for(CDynamics2DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          it->second->Reset();
       }
@@ -101,20 +101,20 @@ namespace argos {
 
    void CDynamics2DEngine::Update() {
       /* Update the physics state from the entities */
-      for(CDynamics2DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          it->second->UpdateFromEntityStatus();
       }
       /* Perform the step */
       for(size_t i = 0; i < GetIterations(); ++i) {
-         for(CDynamics2DModel::TMap::iterator it = m_tPhysicsModels.begin();
+         for(auto it = m_tPhysicsModels.begin();
              it != m_tPhysicsModels.end(); ++it) {
             it->second->UpdatePhysics();
          }
          cpSpaceStep(m_ptSpace, GetPhysicsClockTick());
       }
       /* Update the simulated space */
-      for(CDynamics2DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          it->second->UpdateEntityStatus();
       }
@@ -125,7 +125,7 @@ namespace argos {
 
    void CDynamics2DEngine::Destroy() {
       /* Empty the physics model map */
-      for(CDynamics2DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          delete it->second;
       }
@@ -238,7 +238,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics2DEngine::RemovePhysicsModel(const std::string& str_id) {
-      CDynamics2DModel::TMap::iterator it = m_tPhysicsModels.find(str_id);
+      auto it = m_tPhysicsModels.find(str_id);
       if(it != m_tPhysicsModels.end()) {
          delete it->second;
          m_tPhysicsModels.erase(it);

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_engine.h
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_engine.h
@@ -173,8 +173,8 @@ namespace argos {
    virtual ~CDynamics2DOperationAdd ## SPACE_ENTITY() {}                \
    SOperationOutcome ApplyTo(CDynamics2DEngine& c_engine,               \
                 SPACE_ENTITY& c_entity) {                               \
-      DYN2D_MODEL* pcPhysModel = new DYN2D_MODEL(c_engine,              \
-                                                 c_entity);             \
+      auto* pcPhysModel = new DYN2D_MODEL(c_engine,                     \
+                                          c_entity);                    \
       c_engine.AddPhysicsModel(c_entity.GetId(),                        \
                                *pcPhysModel);                           \
       c_entity.                                                         \

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_gripping.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_gripping.cpp
@@ -22,8 +22,8 @@ namespace argos {
       m_cEngine(c_engine),
       m_cGripperEntity(c_gripper_entity),
       m_ptGripperShape(pt_gripper_shape),
-      m_pcGrippee(NULL),
-      m_tConstraint(NULL) {
+      m_pcGrippee(nullptr),
+      m_tConstraint(nullptr) {
       m_ptGripperShape->sensor = 1;
       m_ptGripperShape->collision_type = CDynamics2DEngine::SHAPE_GRIPPER;
       m_ptGripperShape->data = this;
@@ -74,10 +74,10 @@ namespace argos {
       if(IsGripping()) {
          cpSpaceRemoveConstraint(m_cEngine.GetPhysicsSpace(), m_tConstraint);
          cpConstraintFree(m_tConstraint);
-         m_tConstraint = NULL;
+         m_tConstraint = nullptr;
          m_cGripperEntity.ClearGrippedEntity();
          m_pcGrippee->Remove(*this);
-         m_pcGrippee = NULL;
+         m_pcGrippee = nullptr;
       }
    }
 
@@ -110,7 +110,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics2DGrippable::Remove(CDynamics2DGripper& c_gripper) {
-      CDynamics2DGripper::TList::iterator it =
+      auto it =
          std::find(m_listGrippers.begin(), m_listGrippers.end(), &c_gripper);
       if(it != m_listGrippers.end()) {
          m_listGrippers.erase(it);
@@ -121,7 +121,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics2DGrippable::Release(CDynamics2DGripper& c_gripper) {
-      CDynamics2DGripper::TList::iterator it =
+      auto it =
          std::find(m_listGrippers.begin(), m_listGrippers.end(), &c_gripper);
       if(it != m_listGrippers.end()) {
          (*it)->Release();
@@ -146,9 +146,9 @@ namespace argos {
       /* Get the shapes involved */
       CP_ARBITER_GET_SHAPES(pt_arb, ptGripperShape, ptGrippableShape);
       /* Get a reference to the gripper data */
-      CDynamics2DGripper* pcGripper = reinterpret_cast<CDynamics2DGripper*>(ptGripperShape->data);
+      auto* pcGripper = reinterpret_cast<CDynamics2DGripper*>(ptGripperShape->data);
       /* Get a reference to the grippable entity */
-      CDynamics2DGrippable* pcGrippable = reinterpret_cast<CDynamics2DGrippable*>(ptGrippableShape->data);
+      auto* pcGrippable = reinterpret_cast<CDynamics2DGrippable*>(ptGrippableShape->data);
       /* If the entities match, ignore the collision forever */
       return (&(pcGripper->GetGripperEntity().GetParent()) != &(pcGrippable->GetEmbodiedEntity().GetParent()));
    }
@@ -162,7 +162,7 @@ namespace argos {
       /* Get the shapes involved */
       CP_ARBITER_GET_SHAPES(pt_arb, ptGripperShape, ptGrippableShape);
       /* Get a reference to the gripper data */
-      CDynamics2DGripper* pcGripper = reinterpret_cast<CDynamics2DGripper*>(ptGripperShape->data);
+      auto* pcGripper = reinterpret_cast<CDynamics2DGripper*>(ptGripperShape->data);
       /*
        * When to process gripping:
        * 1. when the robot was gripping and it just unlocked the gripper
@@ -200,8 +200,8 @@ namespace argos {
                                                 void* p_obj,
                                                 void* p_data) {
       /* Get the objects involved */
-      CDynamics2DGripper*   pcGripper   = reinterpret_cast<CDynamics2DGripper*>  (p_obj);
-      CDynamics2DGrippable* pcGrippable = reinterpret_cast<CDynamics2DGrippable*>(p_data);
+      auto*   pcGripper   = reinterpret_cast<CDynamics2DGripper*>  (p_obj);
+      auto* pcGrippable = reinterpret_cast<CDynamics2DGrippable*>(p_data);
       /* Connect the objects */
       pcGripper->Grip(pcGrippable);
    }
@@ -213,7 +213,7 @@ namespace argos {
                                                    void* p_obj,
                                                    void* p_data) {
       /* Get the gripper objects */
-      CDynamics2DGripper* pcGripper   = reinterpret_cast<CDynamics2DGripper*>  (p_obj);
+      auto* pcGripper   = reinterpret_cast<CDynamics2DGripper*>  (p_obj);
       /* Disconnect the objects */
       pcGripper->Release();
    }

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_multi_body_object_model.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_multi_body_object_model.cpp
@@ -92,7 +92,7 @@ namespace argos {
       for(size_t i = 0; i < m_vecBodies.size(); ++i) {
          tBoundingBox = cpShapeGetBB(m_vecBodies[i].Body->shapeList);
          for(cpShape* pt_shape = m_vecBodies[i].Body->shapeList->next;
-             pt_shape != NULL;
+             pt_shape != nullptr;
              pt_shape = pt_shape->next) {
             cpBB* ptBB = &pt_shape->bb;
             if(ptBB->l < tBoundingBox.l) tBoundingBox.l = ptBB->l;
@@ -117,12 +117,12 @@ namespace argos {
       if(m_vecBodies.empty()) return false;
       for(size_t i = 0; i < m_vecBodies.size(); ++i) {
          for(cpShape* pt_shape = m_vecBodies[i].Body->shapeList;
-             pt_shape != NULL;
+             pt_shape != nullptr;
              pt_shape = pt_shape->next) {
             if(cpSpaceShapeQuery(
                   const_cast<CDynamics2DMultiBodyObjectModel*>(this)->
                   GetDynamics2DEngine().GetPhysicsSpace(),
-                  pt_shape, NULL, NULL) > 0) {
+                  pt_shape, nullptr, nullptr) > 0) {
                return true;
             }
          }

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_single_body_object_model.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_single_body_object_model.cpp
@@ -10,7 +10,7 @@ namespace argos {
                                                                       CComposableEntity& c_entity) :
       CDynamics2DModel(c_engine, c_entity.GetComponent<CEmbodiedEntity>("body")),
       m_cEntity(c_entity),
-      m_ptBody(NULL) {}
+      m_ptBody(nullptr) {}
 
    /****************************************/
    /****************************************/
@@ -85,7 +85,7 @@ namespace argos {
    void CDynamics2DSingleBodyObjectModel::CalculateBoundingBox() {
       cpBB tBoundingBox = cpShapeGetBB(m_ptBody->shapeList);
       for(cpShape* pt_shape = m_ptBody->shapeList->next;
-          pt_shape != NULL;
+          pt_shape != nullptr;
           pt_shape = pt_shape->next) {
          cpBB* ptBB = &pt_shape->bb;
          if(ptBB->l < tBoundingBox.l) tBoundingBox.l = ptBB->l;
@@ -114,12 +114,12 @@ namespace argos {
 
    bool CDynamics2DSingleBodyObjectModel::IsCollidingWithSomething() const {
       for(cpShape* pt_shape = m_ptBody->shapeList;
-          pt_shape != NULL;
+          pt_shape != nullptr;
           pt_shape = pt_shape->next) {
          if(cpSpaceShapeQuery(
                const_cast<CDynamics2DSingleBodyObjectModel*>(this)->
                GetDynamics2DEngine().GetPhysicsSpace(),
-               pt_shape, NULL, NULL) > 0) {
+               pt_shape, nullptr, nullptr) > 0) {
             return true;
          }
       }

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_stretchable_object_model.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_stretchable_object_model.cpp
@@ -10,20 +10,20 @@ namespace argos {
                                                                         CComposableEntity& c_entity) :
       CDynamics2DSingleBodyObjectModel(c_engine, c_entity),
       m_fMass(0.0f),
-      m_pcGrippable(NULL),
-      m_ptLinearFriction(NULL),
-      m_ptAngularFriction(NULL) {}
+      m_pcGrippable(nullptr),
+      m_ptLinearFriction(nullptr),
+      m_ptAngularFriction(nullptr) {}
 
    /****************************************/
    /****************************************/
 
    CDynamics2DStretchableObjectModel::~CDynamics2DStretchableObjectModel() {
-      if(m_pcGrippable != NULL) delete m_pcGrippable;
-      if(m_ptLinearFriction != NULL) {
+      if(m_pcGrippable != nullptr) delete m_pcGrippable;
+      if(m_ptLinearFriction != nullptr) {
          cpSpaceRemoveConstraint(GetDynamics2DEngine().GetPhysicsSpace(), m_ptLinearFriction);
          cpConstraintFree(m_ptLinearFriction);
       }
-      if(m_ptAngularFriction != NULL) {
+      if(m_ptAngularFriction != nullptr) {
          cpSpaceRemoveConstraint(GetDynamics2DEngine().GetPhysicsSpace(), m_ptAngularFriction);
          cpConstraintFree(m_ptAngularFriction);
       }
@@ -34,7 +34,7 @@ namespace argos {
 
    void CDynamics2DStretchableObjectModel::MoveTo(const CVector3& c_position,
                                                   const CQuaternion& c_orientation) {
-      if(m_pcGrippable != NULL) {
+      if(m_pcGrippable != nullptr) {
          /* Release all attached entities */
          m_pcGrippable->ReleaseAll();
       }
@@ -45,7 +45,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics2DStretchableObjectModel::Reset() {
-      if(m_pcGrippable != NULL) {
+      if(m_pcGrippable != nullptr) {
          /* Release all attached entities */
          m_pcGrippable->ReleaseAll();
       }

--- a/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_velocity_control.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics2d/dynamics2d_velocity_control.cpp
@@ -17,10 +17,10 @@ namespace argos {
                                                           Real f_max_torque,
                                                           TConfigurationNode* t_node) :
       m_cDyn2DEngine(c_engine),
-      m_ptControlBody(NULL),
-      m_ptControlledBody(NULL),
-      m_ptLinearConstraint(NULL),
-      m_ptAngularConstraint(NULL),
+      m_ptControlBody(nullptr),
+      m_ptControlledBody(nullptr),
+      m_ptLinearConstraint(nullptr),
+      m_ptAngularConstraint(nullptr),
       m_fMaxForce(f_max_force),
       m_fMaxTorque(f_max_torque) {
       m_ptControlBody = cpBodyNew(INFINITY, INFINITY);
@@ -47,7 +47,7 @@ namespace argos {
 
    void CDynamics2DVelocityControl::AttachTo(cpBody* pt_body) {
       /* If we are already controlling a body, detach from it first */
-      if(m_ptControlledBody != NULL) {
+      if(m_ptControlledBody != nullptr) {
          Detach();
       }
       /* Set the wanted body as the new controlled one */
@@ -76,7 +76,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics2DVelocityControl::Detach() {
-      if(m_ptControlledBody != NULL) {
+      if(m_ptControlledBody != nullptr) {
          /* Remove constraints */
          cpSpaceRemoveConstraint(m_cDyn2DEngine.GetPhysicsSpace(), m_ptLinearConstraint);
          cpSpaceRemoveConstraint(m_cDyn2DEngine.GetPhysicsSpace(), m_ptAngularConstraint);
@@ -84,7 +84,7 @@ namespace argos {
          cpConstraintFree(m_ptLinearConstraint);
          cpConstraintFree(m_ptAngularConstraint);
          /* Erase pointer to controlled body */
-         m_ptControlledBody = NULL;
+         m_ptControlledBody = nullptr;
       }
    }
 

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.cpp
@@ -71,11 +71,11 @@ namespace argos {
 
    void CDynamics3DEngine::Reset() {
       /* Remove and reset all physics models */
-      for(CDynamics3DModel::TMap::iterator itModel = std::begin(m_tPhysicsModels);
+      for(auto itModel = std::begin(m_tPhysicsModels);
           itModel != std::end(m_tPhysicsModels);
           ++itModel) {
          /* Remove model from plugins */
-         for(CDynamics3DPlugin::TMap::iterator itPlugin = std::begin(m_tPhysicsPlugins);
+         for(auto itPlugin = std::begin(m_tPhysicsPlugins);
              itPlugin != std::end(m_tPhysicsPlugins);
              ++itPlugin) {
             itPlugin->second->UnregisterModel(*itModel->second);
@@ -103,14 +103,14 @@ namespace argos {
       /* Provide the same random seed to the solver */
       m_cSolver.setRandSeed(m_pcRNG->Uniform(m_cRandomSeedRange));
       /* Reset the plugins */
-      for(CDynamics3DPlugin::TMap::iterator itPlugin = std::begin(m_tPhysicsPlugins);
+      for(auto itPlugin = std::begin(m_tPhysicsPlugins);
           itPlugin != std::end(m_tPhysicsPlugins);
           ++itPlugin) {
          itPlugin->second->Reset();
       }
       /* Set up the call back for the plugins */
       m_cWorld.setInternalTickCallback([] (btDynamicsWorld* pc_world, btScalar f_time_step) {
-         CDynamics3DEngine* pc_engine = static_cast<CDynamics3DEngine*>(pc_world->getWorldUserInfo());
+         auto* pc_engine = static_cast<CDynamics3DEngine*>(pc_world->getWorldUserInfo());
          pc_world->clearForces();
          for(std::pair<const std::string, CDynamics3DPlugin*>& c_plugin :
              pc_engine->GetPhysicsPlugins()) {
@@ -118,11 +118,11 @@ namespace argos {
          }
       }, static_cast<void*>(this), true);
       /* Add the models back into the engine */
-      for(CDynamics3DModel::TMap::iterator itModel = std::begin(m_tPhysicsModels);
+      for(auto itModel = std::begin(m_tPhysicsModels);
           itModel != std::end(m_tPhysicsModels);
           ++itModel) {
          /* Add model to plugins */
-         for(CDynamics3DPlugin::TMap::iterator itPlugin = std::begin(m_tPhysicsPlugins);
+         for(auto itPlugin = std::begin(m_tPhysicsPlugins);
              itPlugin != std::end(m_tPhysicsPlugins);
              ++itPlugin) {
             itPlugin->second->RegisterModel(*itModel->second);
@@ -141,11 +141,11 @@ namespace argos {
 
    void CDynamics3DEngine::Destroy() {
       /* Destroy all physics models */
-      for(CDynamics3DModel::TMap::iterator itModel = std::begin(m_tPhysicsModels);
+      for(auto itModel = std::begin(m_tPhysicsModels);
           itModel != std::end(m_tPhysicsModels);
           ++itModel) {
          /* Remove model from the plugins first */
-         for(CDynamics3DPlugin::TMap::iterator itPlugin = std::begin(m_tPhysicsPlugins);
+         for(auto itPlugin = std::begin(m_tPhysicsPlugins);
              itPlugin != std::end(m_tPhysicsPlugins);
              ++itPlugin) {
             itPlugin->second->UnregisterModel(*itModel->second);
@@ -155,7 +155,7 @@ namespace argos {
          delete itModel->second;
       }
       /* Destroy all plug-ins */
-      for(CDynamics3DPlugin::TMap::iterator itPlugin = std::begin(m_tPhysicsPlugins);
+      for(auto itPlugin = std::begin(m_tPhysicsPlugins);
           itPlugin != std::end(m_tPhysicsPlugins);
           ++itPlugin) {
          itPlugin->second->Destroy();
@@ -171,7 +171,7 @@ namespace argos {
 
    void CDynamics3DEngine::Update() {
       /* Update the physics state from the entities */
-      for(CDynamics3DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != std::end(m_tPhysicsModels); ++it) {
          it->second->UpdateFromEntityStatus();
       }
@@ -180,7 +180,7 @@ namespace argos {
                               GetIterations(),
                               GetPhysicsClockTick());
       /* Update the simulated space */
-      for(CDynamics3DModel::TMap::iterator it = std::begin(m_tPhysicsModels);
+      for(auto it = std::begin(m_tPhysicsModels);
           it != std::end(m_tPhysicsModels);
           ++it) {
          it->second->UpdateEntityStatus();
@@ -214,7 +214,7 @@ namespace argos {
       /* Examine the results */
       if (cResult.hasHit() && cResult.m_collisionObject->getUserPointer() != nullptr) {
          Real f_t = (cResult.m_hitPointWorld - cRayStart).length() / c_ray.GetLength();
-         CDynamics3DModel* pcModel =
+         auto* pcModel =
             static_cast<CDynamics3DModel*>(cResult.m_collisionObject->getUserPointer());
          t_data.push_back(SEmbodiedEntityIntersectionItem(&(pcModel->GetEmbodiedEntity()), f_t));
       }
@@ -255,7 +255,7 @@ namespace argos {
       /* Add model to world */
       c_model.AddToWorld(m_cWorld);
       /* Notify the plugins of the added model */
-      for(CDynamics3DPlugin::TMap::iterator itPlugin = std::begin(m_tPhysicsPlugins);
+      for(auto itPlugin = std::begin(m_tPhysicsPlugins);
           itPlugin != std::end(m_tPhysicsPlugins);
           ++itPlugin) {
          itPlugin->second->RegisterModel(c_model);
@@ -268,10 +268,10 @@ namespace argos {
    /****************************************/
 
    void CDynamics3DEngine::RemovePhysicsModel(const std::string& str_id) {
-      CDynamics3DModel::TMap::iterator itModel = m_tPhysicsModels.find(str_id);
+      auto itModel = m_tPhysicsModels.find(str_id);
       if(itModel != std::end(m_tPhysicsModels)) {
          /* Notify the plugins of model removal */
-         for(CDynamics3DPlugin::TMap::iterator itPlugin = std::begin(m_tPhysicsPlugins);
+         for(auto itPlugin = std::begin(m_tPhysicsPlugins);
              itPlugin != std::end(m_tPhysicsPlugins);
              ++itPlugin) {
             itPlugin->second->UnregisterModel(*(itModel->second));
@@ -302,7 +302,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics3DEngine::RemovePhysicsPlugin(const std::string& str_id) {
-      CDynamics3DPlugin::TMap::iterator it = m_tPhysicsPlugins.find(str_id);
+      auto it = m_tPhysicsPlugins.find(str_id);
       if(it != std::end(m_tPhysicsPlugins)) {
          delete it->second;
          m_tPhysicsPlugins.erase(it);

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.h
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_engine.h
@@ -147,8 +147,8 @@ namespace argos {
    virtual ~CDynamics3DOperationAdd ## SPACE_ENTITY() {}                \
    SOperationOutcome ApplyTo(CDynamics3DEngine& c_engine,               \
                 SPACE_ENTITY& c_entity) {                               \
-      DYN3D_MODEL* pcPhysModel = new DYN3D_MODEL(c_engine,              \
-                                                 c_entity);             \
+      auto* pcPhysModel = new DYN3D_MODEL(c_engine,                     \
+                                          c_entity);                    \
       c_engine.AddPhysicsModel(c_entity.GetId(),                        \
                                *pcPhysModel);                           \
       c_entity.                                                         \

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_gravity_plugin.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_gravity_plugin.cpp
@@ -33,7 +33,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics3DGravityPlugin::UnregisterModel(CDynamics3DModel& c_model) {
-      std::vector<std::shared_ptr<CDynamics3DModel::CAbstractBody> >::iterator itRemove =
+      auto itRemove =
          std::remove_if(std::begin(m_vecTargets),
                         std::end(m_vecTargets),
                         [&c_model] (const std::shared_ptr<CDynamics3DModel::CAbstractBody>& ptr_body) {

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_magnetism_plugin.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_magnetism_plugin.cpp
@@ -40,7 +40,7 @@ namespace argos {
    /****************************************/
 
    void CDynamics3DMagnetismPlugin::UnregisterModel(CDynamics3DModel& c_model) {
-      std::vector<SMagneticDipole>::iterator itRemove =
+      auto itRemove =
          std::remove_if(std::begin(m_vecDipoles),
                         std::end(m_vecDipoles),
                         [&c_model] (const SMagneticDipole& c_magnetic_dipole) {
@@ -57,10 +57,10 @@ namespace argos {
          /* Nothing to do */
          return;
       }
-      for(std::vector<SMagneticDipole>::iterator itDipole0 = std::begin(m_vecDipoles);
+      for(auto itDipole0 = std::begin(m_vecDipoles);
           itDipole0 != (std::end(m_vecDipoles) - 1);
           ++itDipole0) {
-         for(std::vector<SMagneticDipole>::iterator itDipole1 = std::next(itDipole0, 1);
+         for(auto itDipole1 = std::next(itDipole0, 1);
              itDipole1 != std::end(m_vecDipoles);
              ++itDipole1) {
             const btTransform& cTransformDipole0 = itDipole0->Offset * itDipole0->Body->GetTransform();

--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_model.cpp
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_model.cpp
@@ -115,9 +115,9 @@ namespace argos {
       for(SInt32 i = 0; i < cDispatcher.getNumManifolds(); i++) {
          const btPersistentManifold* pcContactManifold =
             cDispatcher.getManifoldByIndexInternal(i);
-         const CDynamics3DModel* pcModelA =
+         const auto* pcModelA =
             static_cast<const CDynamics3DModel*>(pcContactManifold->getBody0()->getUserPointer());
-         const CDynamics3DModel* pcModelB =
+         const auto* pcModelB =
             static_cast<const CDynamics3DModel*>(pcContactManifold->getBody1()->getUserPointer());
          /* Ignore self-collisions */
          if(pcModelA == pcModelB) {

--- a/src/plugins/simulator/physics_engines/physx/physx_engine.h
+++ b/src/plugins/simulator/physics_engines/physx/physx_engine.h
@@ -364,8 +364,8 @@ namespace argos {
    virtual ~CPhysXOperationAdd ## SPACE_ENTITY() {}                     \
    SOperationOutcome ApplyTo(CPhysXEngine& c_engine,                    \
                              SPACE_ENTITY& c_entity) {                  \
-      PHYSX_MODEL* pcPhysModel = new PHYSX_MODEL(c_engine,              \
-                                                 c_entity);             \
+      auto* pcPhysModel = new PHYSX_MODEL(c_engine,                     \
+                                          c_entity);                    \
       c_engine.AddPhysicsModel(c_entity.GetId(),                        \
                                *pcPhysModel);                           \
       c_entity.                                                         \

--- a/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_engine.cpp
+++ b/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_engine.cpp
@@ -38,7 +38,7 @@ namespace argos {
    /****************************************/
 
    void CPointMass3DEngine::Reset() {
-      for(CPointMass3DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          it->second->Reset();
       }
@@ -49,7 +49,7 @@ namespace argos {
 
    void CPointMass3DEngine::Destroy() {
       /* Empty the physics entity map */
-      for(CPointMass3DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          delete it->second;
       }
@@ -61,23 +61,23 @@ namespace argos {
 
    void CPointMass3DEngine::Update() {
       /* Update the physics state from the entities */
-      for(CPointMass3DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          it->second->UpdateFromEntityStatus();
       }
       for(size_t i = 0; i < GetIterations(); ++i) {
          /* Perform the step */
-         for(CPointMass3DModel::TMap::iterator it = m_tPhysicsModels.begin();
+         for(auto it = m_tPhysicsModels.begin();
              it != m_tPhysicsModels.end(); ++it) {
             it->second->UpdatePhysics();
          }
       }
-      for(CPointMass3DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          it->second->Step();
       }
       /* Update the simulated space */
-      for(CPointMass3DModel::TMap::iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end(); ++it) {
          it->second->UpdateEntityStatus();
       }
@@ -136,7 +136,7 @@ namespace argos {
    void CPointMass3DEngine::CheckIntersectionWithRay(TEmbodiedEntityIntersectionData& t_data,
                                                      const CRay3& c_ray) const {
       Real fTOnRay;
-      for(CPointMass3DModel::TMap::const_iterator it = m_tPhysicsModels.begin();
+      for(auto it = m_tPhysicsModels.begin();
           it != m_tPhysicsModels.end();
           ++it) {
          if(it->second->CheckIntersectionWithRay(fTOnRay, c_ray)) {
@@ -160,7 +160,7 @@ namespace argos {
    /****************************************/
 
    void CPointMass3DEngine::RemovePhysicsModel(const std::string& str_id) {
-      CPointMass3DModel::TMap::iterator it = m_tPhysicsModels.find(str_id);
+      auto it = m_tPhysicsModels.find(str_id);
       if(it != m_tPhysicsModels.end()) {
          delete it->second;
          m_tPhysicsModels.erase(it);

--- a/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_engine.h
+++ b/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_engine.h
@@ -98,8 +98,8 @@ namespace argos {
    virtual ~CPointMass3DOperationAdd ## SPACE_ENTITY() {}               \
    SOperationOutcome ApplyTo(CPointMass3DEngine& c_engine,              \
                              SPACE_ENTITY& c_entity) {                  \
-      PM3D_MODEL* pcPhysModel = new PM3D_MODEL(c_engine,                \
-                                               c_entity);               \
+      auto* pcPhysModel = new PM3D_MODEL(c_engine,                      \
+                                         c_entity);                     \
       c_engine.AddPhysicsModel(c_entity.GetId(),                        \
                                *pcPhysModel);                           \
       c_entity.                                                         \

--- a/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_model.cpp
+++ b/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_model.cpp
@@ -41,7 +41,7 @@ namespace argos {
 
    bool CPointMass3DModel::IsCollidingWithSomething() const {
       /* Go through other objects and check if the BB intersect */
-      for(std::map<std::string, CPointMass3DModel*>::const_iterator it = GetPM3DEngine().GetPhysicsModels().begin();
+      for(auto it = GetPM3DEngine().GetPhysicsModels().begin();
           it != GetPM3DEngine().GetPhysicsModels().end(); ++it) {
          if((it->second != this) &&
             GetBoundingBox().Intersects(it->second->GetBoundingBox()))

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_camera.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_camera.cpp
@@ -325,13 +325,13 @@ namespace argos {
                 itTimeline != itTimeline.end();
                 ++itTimeline) {
                /* Create timeline item */
-               STimelineItem* psTimelineItem = new STimelineItem();
+               auto* psTimelineItem = new STimelineItem();
                psTimelineItem->Init(*itTimeline);
                /* Sorted insert */
                if(m_listTimeline.empty())
                   m_listTimeline.push_back(psTimelineItem);
                else {
-                  std::list<STimelineItem*>::iterator it = m_listTimeline.begin();
+                  auto it = m_listTimeline.begin();
                   while(it != m_listTimeline.end() && (*it)->Step < psTimelineItem->Step) ++it;
                   if(it == m_listTimeline.end())
                      m_listTimeline.push_back(psTimelineItem);
@@ -339,7 +339,7 @@ namespace argos {
                      m_listTimeline.insert(it, psTimelineItem);
                }
             }
-            for(std::list<STimelineItem*>::iterator it = m_listTimeline.begin();
+            for(auto it = m_listTimeline.begin();
                 it != m_listTimeline.end();
                 ++it) {
             }
@@ -392,7 +392,7 @@ namespace argos {
       /* Get current timestep */
       UInt32 unStep = CSimulator::GetInstance().GetSpace().GetSimulationClock();
       /* Search for active timeline item */
-      std::list<STimelineItem*>::iterator it = m_listTimeline.begin();
+      auto it = m_listTimeline.begin();
       /* Is the first item potentially active? */
       if((*it)->Step <= unStep) {
          /* Yes, save it and search for subsequent items */

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_main_window.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_main_window.cpp
@@ -47,38 +47,38 @@ namespace argos {
    public:
 
       CQTOpenGLLayout() :
-         m_pcQTOpenGLItem(NULL) {
+         m_pcQTOpenGLItem(nullptr) {
          setContentsMargins(0, 0, 0, 0);
       }
 
       virtual ~CQTOpenGLLayout() {
-         if(m_pcQTOpenGLItem != NULL) {
+         if(m_pcQTOpenGLItem != nullptr) {
             delete m_pcQTOpenGLItem;
          }
       }
 
       virtual void addItem(QLayoutItem* item) {
-         if(m_pcQTOpenGLItem != NULL) {
+         if(m_pcQTOpenGLItem != nullptr) {
             delete m_pcQTOpenGLItem;
          }
          m_pcQTOpenGLItem = item;
       }
       virtual int count() const {
-         return (m_pcQTOpenGLItem != NULL) ? 1 : 0;
+         return (m_pcQTOpenGLItem != nullptr) ? 1 : 0;
       }
 
       virtual QLayoutItem* itemAt(int index) const {
-         return (index == 0) ? m_pcQTOpenGLItem : NULL;
+         return (index == 0) ? m_pcQTOpenGLItem : nullptr;
       }
 
       virtual QLayoutItem* takeAt(int index) {
          if(index == 0) {
             QLayoutItem* pcRetVal = m_pcQTOpenGLItem;
-            m_pcQTOpenGLItem = NULL;
+            m_pcQTOpenGLItem = nullptr;
             return pcRetVal;
          }
          else {
-            return NULL;
+            return nullptr;
          }
       }
 
@@ -88,7 +88,7 @@ namespace argos {
       virtual void setGeometry(const QRect& r) {
          /* Set the layout geometry */
          QLayout::setGeometry(r);
-         if(m_pcQTOpenGLItem != NULL) {
+         if(m_pcQTOpenGLItem != nullptr) {
             /* Calculate the candidate sizes for the QTOpenGL widget */
             /* One is height-driven */
             QRect cCandidate1(r.x(), r.y(), (r.height() * 4) / 3, r.height());
@@ -120,7 +120,7 @@ namespace argos {
    /****************************************/
 
    CQTOpenGLMainWindow::CQTOpenGLMainWindow(TConfigurationNode& t_tree) :
-      m_pcUserFunctions(NULL) {
+      m_pcUserFunctions(nullptr) {
       /* Main window settings */
       std::string strTitle;
       GetNodeAttributeOrDefault<std::string>(t_tree, "title", strTitle, "ARGoS v" ARGOS_VERSION "-" ARGOS_RELEASE);
@@ -467,7 +467,7 @@ namespace argos {
       GetNodeAttributeOrDefault(t_tree, "show_boundary", bShowBoundary, true);
       m_pcOpenGLWidget->SetShowBoundary(bShowBoundary);
       /* Set the window as the central widget */
-      CQTOpenGLLayout* pcQTOpenGLLayout = new CQTOpenGLLayout();
+      auto* pcQTOpenGLLayout = new CQTOpenGLLayout();
       pcQTOpenGLLayout->addWidget(m_pcOpenGLWidget);
       pcPlaceHolder->setLayout(pcQTOpenGLLayout);
       setCentralWidget(pcPlaceHolder);
@@ -882,7 +882,7 @@ namespace argos {
 
    void CQTOpenGLMainWindow::CameraXMLPopUp() {
       /* Set the text window up */
-      QTextEdit* pcXMLOutput = new QTextEdit();
+      auto* pcXMLOutput = new QTextEdit();
       /* Calculate the geometry of the window so that it's 1/4 of the main window
          and placed in the exact center of it */
       QRect cGeom = geometry();

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_obj_model.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_obj_model.cpp
@@ -48,7 +48,7 @@ namespace argos {
    /****************************************/
 
    CQTOpenGLObjModel::SMaterial& CQTOpenGLObjModel::GetMaterial(const std::string& str_material) {
-      SMaterial::TMapIterator tIter = m_mapMaterials.find(str_material);
+      auto tIter = m_mapMaterials.find(str_material);
       if(tIter == std::end(m_mapMaterials)) {
          THROW_ARGOSEXCEPTION("Material \"" << str_material << "\" is undefined");
       }
@@ -102,7 +102,7 @@ namespace argos {
    const QString& CQTOpenGLObjModel::GetModelDir() const {
       /* get a reference to the visualization */
       CVisualization& cVisualization = CSimulator::GetInstance().GetVisualization();
-      CQTOpenGLRender& cQtOpenGLRender = dynamic_cast<CQTOpenGLRender&>(cVisualization);
+      auto& cQtOpenGLRender = dynamic_cast<CQTOpenGLRender&>(cVisualization);
       /* return the model directory */
       return cQtOpenGLRender.GetMainWindow().GetModelDir();
    }
@@ -112,7 +112,7 @@ namespace argos {
 
    void CQTOpenGLObjModel::ImportGeometry(QTextStream& c_text_stream) {
       /* select the default material */
-      SMaterial::TMapIterator itSelectedMaterial =
+      auto itSelectedMaterial =
          m_mapMaterials.find("__default_material");
       /* define a functor for adjusting negative indices found in the obj model */
       struct {
@@ -294,7 +294,7 @@ namespace argos {
 
    void CQTOpenGLObjModel::ImportMaterials(QTextStream& c_text_stream) {
       /* select the default material */
-      SMaterial::TMapIterator itMaterial =
+      auto itMaterial =
          m_mapMaterials.find("__default_material");
       /* create a buffer for parsing the input */
       QString strLineBuffer;
@@ -372,7 +372,7 @@ namespace argos {
       std::pair<TCacheIterator, TCacheIterator> cRange =
          m_mapVertexCache.equal_range(n_key);
       /* check if the vertex already exists in the cache */
-      TCacheIterator itVertex =
+      auto itVertex =
          std::find_if(cRange.first,
                       cRange.second,
                       [this, &c_position, &c_normal, &c_texture] (const TCacheEntry& c_entry) {
@@ -392,7 +392,7 @@ namespace argos {
    /****************************************/
 
    void CQTOpenGLObjModel::BuildMeshes() {
-      SMaterial::TMapIterator itCurrentMaterial = std::end(m_mapMaterials);
+      auto itCurrentMaterial = std::end(m_mapMaterials);
       for(const STriangle& s_triangle : m_vecTriangles) {
          if(s_triangle.Material != itCurrentMaterial) {
             /* select the current material */

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_render.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_render.cpp
@@ -91,7 +91,7 @@ namespace argos {
    /****************************************/
 
    CQTOpenGLMainWindow& CQTOpenGLRender::GetMainWindow() {
-      if(m_pcMainWindow == NULL) {
+      if(m_pcMainWindow == nullptr) {
          THROW_ARGOSEXCEPTION("CQTOpenGLRender::GetMainWindow(): no main window created");
       }
       return *m_pcMainWindow;

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.cpp
@@ -38,8 +38,8 @@ namespace argos {
 
    CQTOpenGLUserFunctions::CQTOpenGLUserFunctions() :
       m_vecFunctionHolders(1),
-      m_pcQTOpenGLMainWindow(NULL) {
-      m_cThunks.Add<CEntity>((TThunk)NULL);
+      m_pcQTOpenGLMainWindow(nullptr) {
+      m_cThunks.Add<CEntity>((TThunk)nullptr);
    }
 
    /****************************************/

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.cpp
@@ -53,8 +53,8 @@ namespace argos {
       m_cSpace(m_cSimulator.GetSpace()),
       m_bShowBoundary(true),
       m_bUsingFloorTexture(false),
-      m_pcFloorTexture(NULL),
-      m_pcGroundTexture(NULL) {
+      m_pcFloorTexture(nullptr),
+      m_pcGroundTexture(nullptr) {
       /* Set the widget's size policy */
       QSizePolicy cSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
       cSizePolicy.setHeightForWidth(true);
@@ -155,7 +155,7 @@ namespace argos {
       DrawArena();
       /* Draw the objects */
       CEntity::TVector& vecEntities = m_cSpace.GetRootEntityVector();
-      for(CEntity::TVector::iterator itEntities = vecEntities.begin();
+      for(auto itEntities = vecEntities.begin();
           itEntities != vecEntities.end();
           ++itEntities) {
          glPushMatrix();
@@ -198,7 +198,7 @@ namespace argos {
          grabFramebuffer()
             .save(
                strFileName,
-               0,
+               nullptr,
                m_sFrameGrabData.Quality);
       }
    }
@@ -297,7 +297,7 @@ namespace argos {
    CEntity* CQTOpenGLWidget::GetSelectedEntity() {
       return (m_sSelectionInfo.IsSelected ?
               m_sSelectionInfo.Entity :
-              NULL);
+              nullptr);
    }
 
    /****************************************/
@@ -824,11 +824,11 @@ namespace argos {
          m_sSelectionInfo.IsSelected &&
          (pc_event->modifiers() & Qt::ControlModifier)) {
          /* Treat selected entity as an embodied entity */
-         CEmbodiedEntity* pcEntity = dynamic_cast<CEmbodiedEntity*>(m_sSelectionInfo.Entity);
-         if(pcEntity == NULL) {
+         auto* pcEntity = dynamic_cast<CEmbodiedEntity*>(m_sSelectionInfo.Entity);
+         if(pcEntity == nullptr) {
             /* Treat selected entity as a composable entity with an embodied component */
-            CComposableEntity* pcCompEntity = dynamic_cast<CComposableEntity*>(m_sSelectionInfo.Entity);
-            if(pcCompEntity != NULL && pcCompEntity->HasComponent("body")) {
+            auto* pcCompEntity = dynamic_cast<CComposableEntity*>(m_sSelectionInfo.Entity);
+            if(pcCompEntity != nullptr && pcCompEntity->HasComponent("body")) {
                pcEntity = &pcCompEntity->GetComponent<CEmbodiedEntity>("body");
             }
             else {
@@ -911,11 +911,11 @@ namespace argos {
    void CQTOpenGLWidget::wheelEvent(QWheelEvent *pc_event) {
       if(m_sSelectionInfo.IsSelected && (pc_event->modifiers() & Qt::ControlModifier)) {
          /* Treat selected entity as an embodied entity */
-         CEmbodiedEntity* pcEntity = dynamic_cast<CEmbodiedEntity*>(m_sSelectionInfo.Entity);
-         if(pcEntity == NULL) {
+         auto* pcEntity = dynamic_cast<CEmbodiedEntity*>(m_sSelectionInfo.Entity);
+         if(pcEntity == nullptr) {
             /* Treat selected entity as a composable entity with an embodied component */
-            CComposableEntity* pcCompEntity = dynamic_cast<CComposableEntity*>(m_sSelectionInfo.Entity);
-            if(pcCompEntity != NULL && pcCompEntity->HasComponent("body")) {
+            auto* pcCompEntity = dynamic_cast<CComposableEntity*>(m_sSelectionInfo.Entity);
+            if(pcCompEntity != nullptr && pcCompEntity->HasComponent("body")) {
                pcEntity = &pcCompEntity->GetComponent<CEmbodiedEntity>("body");
             }
             else {

--- a/src/testing/experiment/test_loop_functions.cpp
+++ b/src/testing/experiment/test_loop_functions.cpp
@@ -14,9 +14,9 @@
 void CTestLoopFunctions::Init(TConfigurationNode& t_tree) {
    LOG << "CTestLoopFunctions init running!\n";
    CFootBotEntity& fb = dynamic_cast<CFootBotEntity&>(GetSpace().GetEntity("fb"));
-   CLEDEntity& cLedA = fb.GetComponent<CLEDEntity>("leds.led[led_2]");
-   CLEDEntity& cLedB = fb.GetComponent<CLEDEntity>("leds.led[led_3]");
-   CLEDEntity& cLedC = fb.GetComponent<CLEDEntity>("leds.led[led_4]");
+   auto& cLedA = fb.GetComponent<CLEDEntity>("leds.led[led_2]");
+   auto& cLedB = fb.GetComponent<CLEDEntity>("leds.led[led_3]");
+   auto& cLedC = fb.GetComponent<CLEDEntity>("leds.led[led_4]");
    
    cLedA.SetColor(CColor::GREEN);
    cLedB.SetColor(CColor::BLUE);

--- a/src/testing/experiment/test_user_functions.cpp
+++ b/src/testing/experiment/test_user_functions.cpp
@@ -23,12 +23,12 @@ CTestUserFunctions::~CTestUserFunctions() {
 void CTestUserFunctions::DrawInWorld() {
    CSpace& cSpace = CSimulator::GetInstance().GetSpace();
    CSpace::TMapPerType& tFBMap = cSpace.GetEntitiesByType("foot-bot");
-   for(CSpace::TMapPerType::iterator it = tFBMap.begin();
+   for(auto it = tFBMap.begin();
        it != tFBMap.end();
        ++it) {
       CFootBotEntity& cFB = *any_cast<CFootBotEntity*>(it->second);
       CLEDEquippedEntity& cLEDs = cFB.GetLEDEquippedEntity();
-      for(CLEDEquippedEntity::SActuator::TList::iterator it = cLEDs.GetLEDs().begin();
+      for(auto it = cLEDs.GetLEDs().begin();
           it != cLEDs.GetLEDs().end();
           ++it) {
          DrawPoint((*it)->LED.GetPosition(), (*it)->LED.GetColor(), 50.0f);

--- a/src/testing/unit/test-range.cpp
+++ b/src/testing/unit/test-range.cpp
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
       std::cerr << "Usage: test-range <seed>" << std::endl;
       abort();
    }
-   UInt32 unSeed = FromString<UInt32>(argv[1]);
+   auto unSeed = FromString<UInt32>(argv[1]);
    CRandom::CreateCategory("argos", unSeed);
    CRandom::CRNG* pcRNG = CRandom::CreateRNG("argos");
    UInt32 unMax = 2;


### PR DESCRIPTION
@ilpincy You had mentioned wanted to modernize ARGos using `auto`, so I went ahead and did that using clang-tidy. I also switched from `NULL` -> `nullptr`, as that is also part of the C++11 standard, and a similarly easy change to make. I looked over the changes clang-tidy made, and I didn't see anything that warranted extra review--let me know what you think.