### PR TITLE
Fixes bug in collision detection code of Chipmunk2D physics library

### DIFF
--- a/src/plugins/simulator/physics_engines/dynamics2d/chipmunk-physics/src/cpSpaceQuery.c
+++ b/src/plugins/simulator/physics_engines/dynamics2d/chipmunk-physics/src/cpSpaceQuery.c
@@ -217,7 +217,7 @@ shapeQueryHelper(cpShape *a, cpShape *b, shapeQueryContext *context)
 	}
 	
 	if(numContacts){
-		context->anyCollision = !(a->sensor || b->sensor);
+		context->anyCollision |= !(a->sensor || b->sensor);
 		
 		if(context->func){
 			cpContactPointSet set = {numContacts, {}};


### PR DESCRIPTION
Fixes bug in collision detection code of Chipmunk2D physics library used by the dynamics 2D engine. Previously, the `anyCollision` flag would sometimes get cleared erroneously after a collision had already been detected. This affects the `IsCollidingWithSomething` function of `CDynamics2DSingleBodyObjectModel` and `CDynamics2DMultiBodyObjectModel`, which both call `cpSpaceShapeQuery`.

Fixes issue #147.