### PR TITLE
Add missing include <limits>

### DIFF
--- a/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_magnetism_plugin.h
+++ b/src/plugins/simulator/physics_engines/dynamics3d/dynamics3d_magnetism_plugin.h
@@ -14,6 +14,7 @@
 #include <argos3/plugins/simulator/entities/magnet_equipped_entity.h>
 #include <argos3/core/utility/datatypes/datatypes.h>
 #include <functional>
+#include <limits>
 #include <vector>
 
 namespace argos {


### PR DESCRIPTION
ARGoS does not compile with GCC 11 / libstdc++ 11:
`error: 'numeric_limits' is not a member of 'std'`.
This is due to missing include `<limits>`.