### PR TITLE
Nested proximity sensor enable/disable incorrect

### DIFF
--- a/src/plugins/robots/eye-bot/simulator/eyebot_proximity_default_sensor.cpp
+++ b/src/plugins/robots/eye-bot/simulator/eyebot_proximity_default_sensor.cpp
@@ -82,6 +82,22 @@ namespace argos {
    /****************************************/
    /****************************************/
 
+   void CEyeBotProximityDefaultSensor::Enable() {
+     CCI_Sensor::Enable();
+     m_pcProximityImpl->Enable();
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CEyeBotProximityDefaultSensor::Disable() {
+     CCI_Sensor::Disable();
+     m_pcProximityImpl->Disable();
+   }
+
+   /****************************************/
+   /****************************************/
+
    REGISTER_SENSOR(CEyeBotProximityDefaultSensor,
                    "eyebot_proximity", "default",
                    "Carlo Pinciroli [ilpincy@gmail.com]",

--- a/src/plugins/robots/eye-bot/simulator/eyebot_proximity_default_sensor.h
+++ b/src/plugins/robots/eye-bot/simulator/eyebot_proximity_default_sensor.h
@@ -36,6 +36,10 @@ namespace argos {
 
       virtual void Reset();
 
+      virtual void Enable();
+
+      virtual void Disable();
+
    private:
 
       CProximityDefaultSensor* m_pcProximityImpl;

--- a/src/plugins/robots/foot-bot/control_interface/ci_footbot_proximity_sensor.h
+++ b/src/plugins/robots/foot-bot/control_interface/ci_footbot_proximity_sensor.h
@@ -77,6 +77,7 @@ namespace argos {
        */
       const TReadings& GetReadings() const;
 
+
 #ifdef ARGOS_WITH_LUA
       virtual void CreateLuaState(lua_State* pt_lua_state);
 

--- a/src/plugins/robots/foot-bot/simulator/footbot_proximity_default_sensor.cpp
+++ b/src/plugins/robots/foot-bot/simulator/footbot_proximity_default_sensor.cpp
@@ -82,6 +82,23 @@ namespace argos {
    /****************************************/
    /****************************************/
 
+   void CFootBotProximityDefaultSensor::Enable() {
+     CCI_Sensor::Enable();
+     m_pcProximityImpl->Enable();
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CFootBotProximityDefaultSensor::Disable() {
+     CCI_Sensor::Disable();
+     m_pcProximityImpl->Disable();
+   }
+
+
+   /****************************************/
+   /****************************************/
+
    REGISTER_SENSOR(CFootBotProximityDefaultSensor,
                    "footbot_proximity", "default",
                    "Carlo Pinciroli [ilpincy@gmail.com]",

--- a/src/plugins/robots/foot-bot/simulator/footbot_proximity_default_sensor.h
+++ b/src/plugins/robots/foot-bot/simulator/footbot_proximity_default_sensor.h
@@ -36,6 +36,12 @@ namespace argos {
 
       virtual void Reset();
 
+      virtual void Enable();
+
+      virtual void Disable();
+
+
+
    private:
 
       CProximityDefaultSensor* m_pcProximityImpl;


### PR DESCRIPTION
Because the actual implementation is nested, you need to both set the boolean
flag for enable-disable for the parent sensor, and do the same for the nested
implementation in order to actually be able to disable the sensor.