### PR TITLE
feat(gitpod): initial cfg example

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt update -y && sudo apt-get install cmake libfreeimage-dev libfreeimageplus-dev \
+  qt5-default freeglut3-dev libxi-dev libxmu-dev liblua5.3-dev \
+  lua5.3 doxygen graphviz libgraphviz-dev asciidoc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: |
+    cd src/argos3
+    mkdir build_simulator && cd build_simulator
+    cmake ..
+    make


### PR DESCRIPTION
Mash this link to test the PR in Gitpod - https://gitpod.io#https://github.com/ilpincy/argos3/pull/184

# next steps
- [ ] adjust gitpod.yml with the build steps
- [ ] 🎉

# notes
note: instructions in README don't work

 /workspace/argos3/src/argos3/argos3/build_simulator $ cmake ..
-- GCC/G++ version >= 4.3
-- Could NOT find GooglePerfTools (missing: GOOGLEPERFTOOLS_LIBRARY GOOGLEPERFTOOLS_INCLUDE_DIR)
-- Found Qt5: version
-- Found Qt5Widgets: version 5.12.8
-- Found Qt5Gui: version 5.12.8
CMake Error at /workspace/argos3/src/argos3/argos3/argos3/argos3/argos3/argos3/argos3/plugins/CMakeLists.txt:5 (add_subdirectory):
  add_subdirectory not given a binary directory but the given source
  directory
  "/workspace/argos3/src/argos3/argos3/argos3/argos3/argos3/argos3/argos3/argos3/argos3/plugins/simulator"
  is not a subdirectory of
  "/workspace/argos3/src/argos3/argos3/argos3/argos3/argos3/argos3/argos3/plugins".
  When specifying an out-of-tree source a binary directory must be explicitly
  specified.

CMake Error at /workspace/argos3/src/argos3/argos3/argos3/argos3/argos3/argos3/argos3/plugins/CMakeLists.txt:11 (add_subdirectory):
  add_subdirectory not given a binary directory but the given source
  directory
  "/workspace/argos3/src/argos3/argos3/argos3/argos3/argos3/argos3/argos3/argos3/argos3/plugins/robots"
  is not a subdirectory of
  "/workspace/argos3/src/argos3/argos3/argos3/argos3/argos3/argos3/argos3/plugins".
  When specifying an out-of-tree source a binary directory must be explicitly
  specified.