### PR TITLE
Add drone camera GetSensorConfiguration interface for potential hardware calibration

### DIFF
--- a/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.cpp
+++ b/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.cpp
@@ -68,7 +68,7 @@ namespace argos {
          CLuaUtility::StartTable(pt_lua_state, s_interface.Label);
          /* add data about this interfaces transform */
          CLuaUtility::StartTable(pt_lua_state, "transform");
-         CLuaUtility::AddToTable(pt_lua_state, "position", 
+         CLuaUtility::AddToTable(pt_lua_state, "position",
             std::get<CVector3>(s_interface.GetConfiguration()));
          CLuaUtility::AddToTable(pt_lua_state, "orientation",
             std::get<CQuaternion>(s_interface.GetConfiguration()));
@@ -143,6 +143,44 @@ namespace argos {
       lua_pop(pt_lua_state, 1);
    }
 #endif
+
+   /****************************************/
+   /****************************************/
+
+   const UInt32 CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_RESOLUTION_X = 700;
+   const UInt32 CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_RESOLUTION_Y = 700;
+   const Real CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_FOCAL_LENGTH_X = 1040.0;
+   const Real CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_FOCAL_LENGTH_Y = 1040.0;
+   const Real CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_PRINCIPAL_POINT_X = 350.0;
+   const Real CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_PRINCIPAL_POINT_Y = 350.0;
+   const Real CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_XY_OFFSET = 0.12;
+   const Real CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_Z_OFFSET = 0.16;
+   const CDegrees CCI_DroneCamerasSystemSensor::DEFAULT_CAMERA_ANGLE = CDegrees(180 - 18);
+
+   /****************************************/
+   /****************************************/
+
+   const std::map<std::string, CCI_DroneCamerasSystemSensor::TConfiguration>
+      CCI_DroneCamerasSystemSensor::DEFAULT_SENSOR_CONFIGURATION = {
+      std::make_pair("arm0",
+                     std::make_tuple("origin",
+                                     CVector3( DEFAULT_CAMERA_XY_OFFSET,  DEFAULT_CAMERA_XY_OFFSET, DEFAULT_CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(DEFAULT_CAMERA_ANGLE), CVector3(-1,1,0).Normalize())
+                                        * CQuaternion(CRadians::PI, CVector3::Z))),
+      std::make_pair("arm1",
+                     std::make_tuple("origin",
+                                     CVector3(-DEFAULT_CAMERA_XY_OFFSET,  DEFAULT_CAMERA_XY_OFFSET, DEFAULT_CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(DEFAULT_CAMERA_ANGLE), CVector3(-1,-1,0).Normalize()))),
+      std::make_pair("arm2",
+                     std::make_tuple("origin",
+                                     CVector3(-DEFAULT_CAMERA_XY_OFFSET, -DEFAULT_CAMERA_XY_OFFSET, DEFAULT_CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(DEFAULT_CAMERA_ANGLE), CVector3(1,-1,0).Normalize())
+                                        * CQuaternion(CRadians::PI, CVector3::Z))),
+      std::make_pair("arm3",
+                     std::make_tuple("origin",
+                                     CVector3( DEFAULT_CAMERA_XY_OFFSET, -DEFAULT_CAMERA_XY_OFFSET, DEFAULT_CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(DEFAULT_CAMERA_ANGLE), CVector3(1,1,0).Normalize()))),
+   };
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.cpp
+++ b/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.cpp
@@ -68,9 +68,9 @@ namespace argos {
          CLuaUtility::StartTable(pt_lua_state, s_interface.Label);
          /* add data about this interfaces transform */
          CLuaUtility::StartTable(pt_lua_state, "transform");
-         CLuaUtility::AddToTable(pt_lua_state, "position", std::get<CVector3>(s_interface.Configuration));
-         CLuaUtility::AddToTable(pt_lua_state, "orientation", std::get<CQuaternion>(s_interface.Configuration));
-         CLuaUtility::AddToTable(pt_lua_state, "anchor", std::get<const char*>(s_interface.Configuration));
+         CLuaUtility::AddToTable(pt_lua_state, "position", std::get<CVector3>(s_interface.GetSensorConfiguration()));
+         CLuaUtility::AddToTable(pt_lua_state, "orientation", std::get<CQuaternion>(s_interface.GetSensorConfiguration()));
+         CLuaUtility::AddToTable(pt_lua_state, "anchor", std::get<const char*>(s_interface.GetSensorConfiguration()));
          CLuaUtility::EndTable(pt_lua_state);
          /* push closure for the enable function */
          lua_pushstring(pt_lua_state, "enable");

--- a/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.cpp
+++ b/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.cpp
@@ -68,9 +68,12 @@ namespace argos {
          CLuaUtility::StartTable(pt_lua_state, s_interface.Label);
          /* add data about this interfaces transform */
          CLuaUtility::StartTable(pt_lua_state, "transform");
-         CLuaUtility::AddToTable(pt_lua_state, "position", std::get<CVector3>(s_interface.GetSensorConfiguration()));
-         CLuaUtility::AddToTable(pt_lua_state, "orientation", std::get<CQuaternion>(s_interface.GetSensorConfiguration()));
-         CLuaUtility::AddToTable(pt_lua_state, "anchor", std::get<const char*>(s_interface.GetSensorConfiguration()));
+         CLuaUtility::AddToTable(pt_lua_state, "position", 
+            std::get<CVector3>(s_interface.GetConfiguration()));
+         CLuaUtility::AddToTable(pt_lua_state, "orientation",
+            std::get<CQuaternion>(s_interface.GetConfiguration()));
+         CLuaUtility::AddToTable(pt_lua_state, "anchor",
+            std::get<const char*>(s_interface.GetConfiguration()));
          CLuaUtility::EndTable(pt_lua_state);
          /* push closure for the enable function */
          lua_pushstring(pt_lua_state, "enable");
@@ -140,46 +143,6 @@ namespace argos {
       lua_pop(pt_lua_state, 1);
    }
 #endif
-
-   /****************************************/
-   /****************************************/
-
-   /* constants */
-   const UInt32 CCI_DroneCamerasSystemSensor::CAMERA_RESOLUTION_X = 700;
-   const UInt32 CCI_DroneCamerasSystemSensor::CAMERA_RESOLUTION_Y = 700;
-   const Real CCI_DroneCamerasSystemSensor::CAMERA_FOCAL_LENGTH_X = 1040.0;
-   const Real CCI_DroneCamerasSystemSensor::CAMERA_FOCAL_LENGTH_Y = 1040.0;
-   const Real CCI_DroneCamerasSystemSensor::CAMERA_PRINCIPAL_POINT_X = 350.0;
-   const Real CCI_DroneCamerasSystemSensor::CAMERA_PRINCIPAL_POINT_Y = 350.0;
-   const Real CCI_DroneCamerasSystemSensor::CAMERA_XY_OFFSET = 0.12;
-   const Real CCI_DroneCamerasSystemSensor::CAMERA_Z_OFFSET = 0.16;
-   const CDegrees CCI_DroneCamerasSystemSensor::CAMERA_ANGLE = CDegrees(180 - 18);
-
-   /****************************************/
-   /****************************************/
-
-   /* sensor configuration map */
-   const std::map<std::string, CCI_DroneCamerasSystemSensor::TConfiguration>
-      CCI_DroneCamerasSystemSensor::SENSOR_CONFIGURATION = {
-      std::make_pair("arm0",
-                     std::make_tuple("origin",
-                                     CVector3( CAMERA_XY_OFFSET,  CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(-1,1,0).Normalize())
-                                        * CQuaternion(CRadians::PI, CVector3::Z))),
-      std::make_pair("arm1",
-                     std::make_tuple("origin",
-                                     CVector3(-CAMERA_XY_OFFSET,  CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(-1,-1,0).Normalize()))),
-      std::make_pair("arm2",
-                     std::make_tuple("origin",
-                                     CVector3(-CAMERA_XY_OFFSET, -CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(1,-1,0).Normalize())
-                                        * CQuaternion(CRadians::PI, CVector3::Z))),
-      std::make_pair("arm3",
-                     std::make_tuple("origin",
-                                     CVector3( CAMERA_XY_OFFSET, -CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(1,1,0).Normalize()))),
-   };
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.h
+++ b/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.h
@@ -57,10 +57,9 @@ namespace argos {
          /* methods */
          virtual void Enable();
          virtual void Disable();
-         /* configuration data */
-         const std::string& Label;
-         virtual const TConfiguration& GetSensorConfiguration() const = 0;
-         /* state */
+         virtual const TConfiguration& GetConfiguration() const = 0;
+         /*  data */
+         std::string Label;
          bool Enabled;
          STag::TVector Tags;
          Real Timestamp;
@@ -79,19 +78,6 @@ namespace argos {
 
       virtual void ReadingsToLuaState(lua_State* pt_lua_state);
 #endif
-
-   protected:
-
-      static const UInt32 CAMERA_RESOLUTION_X;
-      static const UInt32 CAMERA_RESOLUTION_Y;
-      static const Real CAMERA_FOCAL_LENGTH_X;
-      static const Real CAMERA_FOCAL_LENGTH_Y;
-      static const Real CAMERA_PRINCIPAL_POINT_X;
-      static const Real CAMERA_PRINCIPAL_POINT_Y;
-      static const Real CAMERA_XY_OFFSET;
-      static const Real CAMERA_Z_OFFSET;
-      static const CDegrees CAMERA_ANGLE;
-      static const std::map<std::string, TConfiguration> SENSOR_CONFIGURATION;
 
    };
 

--- a/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.h
+++ b/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.h
@@ -51,17 +51,15 @@ namespace argos {
 
       struct SInterface {
          /* constructor */
-         SInterface(const std::string& str_label,
-                    const TConfiguration& t_configuration) :
+         SInterface(const std::string& str_label):
             Label(str_label),
-            Configuration(t_configuration),
             Enabled(false) {}
          /* methods */
          virtual void Enable();
          virtual void Disable();
          /* configuration data */
          const std::string& Label;
-         const TConfiguration& Configuration;
+         virtual const TConfiguration& GetSensorConfiguration() const = 0;
          /* state */
          bool Enabled;
          STag::TVector Tags;

--- a/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.h
+++ b/src/plugins/robots/drone/control_interface/ci_drone_cameras_system_sensor.h
@@ -79,6 +79,19 @@ namespace argos {
       virtual void ReadingsToLuaState(lua_State* pt_lua_state);
 #endif
 
+   protected:
+
+      static const UInt32 DEFAULT_CAMERA_RESOLUTION_X;
+      static const UInt32 DEFAULT_CAMERA_RESOLUTION_Y;
+      static const Real DEFAULT_CAMERA_FOCAL_LENGTH_X;
+      static const Real DEFAULT_CAMERA_FOCAL_LENGTH_Y;
+      static const Real DEFAULT_CAMERA_PRINCIPAL_POINT_X;
+      static const Real DEFAULT_CAMERA_PRINCIPAL_POINT_Y;
+      static const Real DEFAULT_CAMERA_XY_OFFSET;
+      static const Real DEFAULT_CAMERA_Z_OFFSET;
+      static const CDegrees DEFAULT_CAMERA_ANGLE;
+      static const std::map<std::string, TConfiguration> DEFAULT_SENSOR_CONFIGURATION;
+
    };
 
 }

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
@@ -130,8 +130,8 @@ namespace argos {
       m_fFarPlaneHeight = fHeightToDepthRatio * CAMERA_RANGE_MAX;
       m_fFarPlaneWidth = fWidthToDepthRatio * CAMERA_RANGE_MAX;
       /* transformation matrix */
-      m_cOffset.SetFromComponents(std::get<CQuaternion>(GetSensorConfiguration()),
-                                  std::get<CVector3>(GetSensorConfiguration()));
+      m_cOffset.SetFromComponents(std::get<CQuaternion>(m_tConfiguration),
+                                  std::get<CVector3>(m_tConfiguration));
    }
 
    /****************************************/
@@ -174,7 +174,7 @@ namespace argos {
          m_cCameraToWorldTransform = cWorldToCameraTransform.GetInverse();
          /* calculate camera direction vectors */
          m_cCameraPosition = cWorldToCameraTransform.GetTranslationVector();
-         m_cCameraOrientation = Anchor.Orientation * std::get<CQuaternion>(GetSensorConfiguration());
+         m_cCameraOrientation = Anchor.Orientation * std::get<CQuaternion>(m_tConfiguration);
          cLookAt = cWorldToCameraTransform * CVector3::Z;
          cUp = -CVector3::Y;
          cUp.Rotate(cWorldToCameraTransform.GetRotationMatrix());
@@ -333,7 +333,7 @@ namespace argos {
    /****************************************/
 
    const CCI_DroneCamerasSystemSensor::TConfiguration&
-      CDroneCamerasSystemDefaultSensor::SSimulatedInterface::GetSensorConfiguration() const {
+      CDroneCamerasSystemDefaultSensor::SSimulatedInterface::GetConfiguration() const {
       return m_tConfiguration;
    }
 
@@ -380,6 +380,44 @@ namespace argos {
       }
       return true;
    }
+
+   /****************************************/
+   /****************************************/
+
+   const UInt32 CDroneCamerasSystemDefaultSensor::CAMERA_RESOLUTION_X = 700;
+   const UInt32 CDroneCamerasSystemDefaultSensor::CAMERA_RESOLUTION_Y = 700;
+   const Real CDroneCamerasSystemDefaultSensor::CAMERA_FOCAL_LENGTH_X = 1040.0;
+   const Real CDroneCamerasSystemDefaultSensor::CAMERA_FOCAL_LENGTH_Y = 1040.0;
+   const Real CDroneCamerasSystemDefaultSensor::CAMERA_PRINCIPAL_POINT_X = 350.0;
+   const Real CDroneCamerasSystemDefaultSensor::CAMERA_PRINCIPAL_POINT_Y = 350.0;
+   const Real CDroneCamerasSystemDefaultSensor::CAMERA_XY_OFFSET = 0.12;
+   const Real CDroneCamerasSystemDefaultSensor::CAMERA_Z_OFFSET = 0.16;
+   const CDegrees CDroneCamerasSystemDefaultSensor::CAMERA_ANGLE = CDegrees(180 - 18);
+
+   /****************************************/
+   /****************************************/
+
+   const std::map<std::string, CCI_DroneCamerasSystemSensor::TConfiguration>
+      CDroneCamerasSystemDefaultSensor::SENSOR_CONFIGURATION = {
+      std::make_pair("arm0",
+                     std::make_tuple("origin",
+                                     CVector3( CAMERA_XY_OFFSET,  CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(-1,1,0).Normalize())
+                                        * CQuaternion(CRadians::PI, CVector3::Z))),
+      std::make_pair("arm1",
+                     std::make_tuple("origin",
+                                     CVector3(-CAMERA_XY_OFFSET,  CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(-1,-1,0).Normalize()))),
+      std::make_pair("arm2",
+                     std::make_tuple("origin",
+                                     CVector3(-CAMERA_XY_OFFSET, -CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(1,-1,0).Normalize())
+                                        * CQuaternion(CRadians::PI, CVector3::Z))),
+      std::make_pair("arm3",
+                     std::make_tuple("origin",
+                                     CVector3( CAMERA_XY_OFFSET, -CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
+                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(1,1,0).Normalize()))),
+   };
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
@@ -112,9 +112,10 @@ namespace argos {
                           const CCI_DroneCamerasSystemSensor::TConfiguration& t_configuration,
                           const SAnchor& s_anchor,
                           CDroneCamerasSystemDefaultSensor& c_parent) :
-      SInterface(str_label, t_configuration),
+      SInterface(str_label),
       Anchor(s_anchor),
-      m_cParent(c_parent) {
+      m_cParent(c_parent),
+      m_tConfiguration(t_configuration) {
       /* set up the project matrix */
       m_cProjectionMatrix.SetIdentityMatrix();
       m_cProjectionMatrix(0,0) = CAMERA_FOCAL_LENGTH_X;
@@ -129,8 +130,8 @@ namespace argos {
       m_fFarPlaneHeight = fHeightToDepthRatio * CAMERA_RANGE_MAX;
       m_fFarPlaneWidth = fWidthToDepthRatio * CAMERA_RANGE_MAX;
       /* transformation matrix */
-      m_cOffset.SetFromComponents(std::get<CQuaternion>(Configuration),
-                                  std::get<CVector3>(Configuration));
+      m_cOffset.SetFromComponents(std::get<CQuaternion>(GetSensorConfiguration()),
+                                  std::get<CVector3>(GetSensorConfiguration()));
    }
 
    /****************************************/
@@ -173,7 +174,7 @@ namespace argos {
          m_cCameraToWorldTransform = cWorldToCameraTransform.GetInverse();
          /* calculate camera direction vectors */
          m_cCameraPosition = cWorldToCameraTransform.GetTranslationVector();
-         m_cCameraOrientation = Anchor.Orientation * std::get<CQuaternion>(Configuration);
+         m_cCameraOrientation = Anchor.Orientation * std::get<CQuaternion>(GetSensorConfiguration());
          cLookAt = cWorldToCameraTransform * CVector3::Z;
          cUp = -CVector3::Y;
          cUp.Rotate(cWorldToCameraTransform.GetRotationMatrix());
@@ -326,6 +327,14 @@ namespace argos {
 
    CVector2 CDroneCamerasSystemDefaultSensor::SSimulatedInterface::GetResolution() const {
       return CVector2(CAMERA_RESOLUTION_X, CAMERA_RESOLUTION_Y);
+   }
+
+   /****************************************/
+   /****************************************/
+
+   const CCI_DroneCamerasSystemSensor::TConfiguration&
+      CDroneCamerasSystemDefaultSensor::SSimulatedInterface::GetSensorConfiguration() const {
+      return m_tConfiguration;
    }
 
    /****************************************/

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
@@ -39,9 +39,9 @@ namespace argos {
          m_pcEmbodiedEntity =
             &(c_entity.GetComponent<CEmbodiedEntity>("body"));
          /* allocate memory for the sensor interfaces */
-         m_vecSimulatedInterfaces.reserve(SENSOR_CONFIGURATION.size());
+         m_vecSimulatedInterfaces.reserve(DEFAULT_SENSOR_CONFIGURATION.size());
          /* get the anchors for the sensor interfaces from m_mapSensorConfig */
-         for(const std::pair<const std::string, TConfiguration>& t_config : SENSOR_CONFIGURATION) {
+         for(const std::pair<const std::string, TConfiguration>& t_config : DEFAULT_SENSOR_CONFIGURATION) {
             const char* pchAnchor = std::get<const char*>(t_config.second);
             const SAnchor& sAnchor =
                c_entity.GetComponent<CEmbodiedEntity>("body").GetAnchor(pchAnchor);
@@ -118,13 +118,13 @@ namespace argos {
       m_tConfiguration(t_configuration) {
       /* set up the project matrix */
       m_cProjectionMatrix.SetIdentityMatrix();
-      m_cProjectionMatrix(0,0) = CAMERA_FOCAL_LENGTH_X;
-      m_cProjectionMatrix(1,1) = CAMERA_FOCAL_LENGTH_Y;
-      m_cProjectionMatrix(0,2) = CAMERA_PRINCIPAL_POINT_X;
-      m_cProjectionMatrix(1,2) = CAMERA_PRINCIPAL_POINT_Y;
+      m_cProjectionMatrix(0,0) = DEFAULT_CAMERA_FOCAL_LENGTH_X;
+      m_cProjectionMatrix(1,1) = DEFAULT_CAMERA_FOCAL_LENGTH_Y;
+      m_cProjectionMatrix(0,2) = DEFAULT_CAMERA_PRINCIPAL_POINT_X;
+      m_cProjectionMatrix(1,2) = DEFAULT_CAMERA_PRINCIPAL_POINT_Y;
       /* calculate fustrum constants */
-      Real fWidthToDepthRatio = (0.5 * CAMERA_RESOLUTION_X) / CAMERA_FOCAL_LENGTH_X;
-      Real fHeightToDepthRatio = (0.5 * CAMERA_RESOLUTION_Y) / CAMERA_FOCAL_LENGTH_Y;
+      Real fWidthToDepthRatio = (0.5 * DEFAULT_CAMERA_RESOLUTION_X) / DEFAULT_CAMERA_FOCAL_LENGTH_X;
+      Real fHeightToDepthRatio = (0.5 * DEFAULT_CAMERA_RESOLUTION_Y) / DEFAULT_CAMERA_FOCAL_LENGTH_Y;
       m_fNearPlaneHeight = fHeightToDepthRatio * CAMERA_RANGE_MIN;
       m_fNearPlaneWidth = fWidthToDepthRatio * CAMERA_RANGE_MIN;
       m_fFarPlaneHeight = fHeightToDepthRatio * CAMERA_RANGE_MAX;
@@ -326,7 +326,7 @@ namespace argos {
    /****************************************/
 
    CVector2 CDroneCamerasSystemDefaultSensor::SSimulatedInterface::GetResolution() const {
-      return CVector2(CAMERA_RESOLUTION_X, CAMERA_RESOLUTION_Y);
+      return CVector2(DEFAULT_CAMERA_RESOLUTION_X, DEFAULT_CAMERA_RESOLUTION_Y);
    }
 
    /****************************************/
@@ -380,44 +380,6 @@ namespace argos {
       }
       return true;
    }
-
-   /****************************************/
-   /****************************************/
-
-   const UInt32 CDroneCamerasSystemDefaultSensor::CAMERA_RESOLUTION_X = 700;
-   const UInt32 CDroneCamerasSystemDefaultSensor::CAMERA_RESOLUTION_Y = 700;
-   const Real CDroneCamerasSystemDefaultSensor::CAMERA_FOCAL_LENGTH_X = 1040.0;
-   const Real CDroneCamerasSystemDefaultSensor::CAMERA_FOCAL_LENGTH_Y = 1040.0;
-   const Real CDroneCamerasSystemDefaultSensor::CAMERA_PRINCIPAL_POINT_X = 350.0;
-   const Real CDroneCamerasSystemDefaultSensor::CAMERA_PRINCIPAL_POINT_Y = 350.0;
-   const Real CDroneCamerasSystemDefaultSensor::CAMERA_XY_OFFSET = 0.12;
-   const Real CDroneCamerasSystemDefaultSensor::CAMERA_Z_OFFSET = 0.16;
-   const CDegrees CDroneCamerasSystemDefaultSensor::CAMERA_ANGLE = CDegrees(180 - 18);
-
-   /****************************************/
-   /****************************************/
-
-   const std::map<std::string, CCI_DroneCamerasSystemSensor::TConfiguration>
-      CDroneCamerasSystemDefaultSensor::SENSOR_CONFIGURATION = {
-      std::make_pair("arm0",
-                     std::make_tuple("origin",
-                                     CVector3( CAMERA_XY_OFFSET,  CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(-1,1,0).Normalize())
-                                        * CQuaternion(CRadians::PI, CVector3::Z))),
-      std::make_pair("arm1",
-                     std::make_tuple("origin",
-                                     CVector3(-CAMERA_XY_OFFSET,  CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(-1,-1,0).Normalize()))),
-      std::make_pair("arm2",
-                     std::make_tuple("origin",
-                                     CVector3(-CAMERA_XY_OFFSET, -CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(1,-1,0).Normalize())
-                                        * CQuaternion(CRadians::PI, CVector3::Z))),
-      std::make_pair("arm3",
-                     std::make_tuple("origin",
-                                     CVector3( CAMERA_XY_OFFSET, -CAMERA_XY_OFFSET, CAMERA_Z_OFFSET),
-                                     CQuaternion(ToRadians(CAMERA_ANGLE), CVector3(1,1,0).Normalize()))),
-   };
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.h
@@ -143,18 +143,6 @@ namespace argos {
       bool m_bShowTagRays;
       std::vector<SSimulatedInterface> m_vecSimulatedInterfaces;
 
-   private:
-      static const UInt32 CAMERA_RESOLUTION_X;
-      static const UInt32 CAMERA_RESOLUTION_Y;
-      static const Real CAMERA_FOCAL_LENGTH_X;
-      static const Real CAMERA_FOCAL_LENGTH_Y;
-      static const Real CAMERA_PRINCIPAL_POINT_X;
-      static const Real CAMERA_PRINCIPAL_POINT_Y;
-      static const Real CAMERA_XY_OFFSET;
-      static const Real CAMERA_Z_OFFSET;
-      static const CDegrees CAMERA_ANGLE;
-      static const std::map<std::string, TConfiguration> SENSOR_CONFIGURATION;
-
    };
 }
 

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.h
@@ -66,7 +66,7 @@ namespace argos {
 
          CVector2 GetResolution() const;
 
-         const TConfiguration& GetSensorConfiguration() const;
+         const TConfiguration& GetConfiguration() const;
 
       private:
 
@@ -138,12 +138,22 @@ namespace argos {
       CControllableEntity* m_pcControllableEntity;
       CEmbodiedEntity* m_pcEmbodiedEntity;
       CPositionalIndex<CTagEntity>* m_pcTagIndex;
-
       /* debugging information */
       bool m_bShowFrustum;
       bool m_bShowTagRays;
-
       std::vector<SSimulatedInterface> m_vecSimulatedInterfaces;
+
+   private:
+      static const UInt32 CAMERA_RESOLUTION_X;
+      static const UInt32 CAMERA_RESOLUTION_Y;
+      static const Real CAMERA_FOCAL_LENGTH_X;
+      static const Real CAMERA_FOCAL_LENGTH_Y;
+      static const Real CAMERA_PRINCIPAL_POINT_X;
+      static const Real CAMERA_PRINCIPAL_POINT_Y;
+      static const Real CAMERA_XY_OFFSET;
+      static const Real CAMERA_Z_OFFSET;
+      static const CDegrees CAMERA_ANGLE;
+      static const std::map<std::string, TConfiguration> SENSOR_CONFIGURATION;
 
    };
 }

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.h
@@ -66,11 +66,16 @@ namespace argos {
 
          CVector2 GetResolution() const;
 
+         const TConfiguration& GetSensorConfiguration() const;
+
       private:
 
          const SAnchor& Anchor;
 
          CDroneCamerasSystemDefaultSensor& m_cParent;
+
+         /* camera position and orientation */
+         const TConfiguration& m_tConfiguration;
 
          /* AprilTag corner offsets / ordering */
          // TODO make static, initialize in CPP


### PR DESCRIPTION
In drone hardware we need to adjust camera position and orientations according to each drone calibration.
Therefore instead of getting directly from a static const default value, we use a virtual function GetSensorConfiguration which is implemented seprately in simulation and hardware to get camera position and orientation.