### PR TITLE
Add a new constructor to CQTOpenGLObjModel

### DIFF
--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_obj_model.cpp
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_obj_model.cpp
@@ -48,6 +48,30 @@ namespace argos {
    /****************************************/
    /****************************************/
 
+   CQTOpenGLObjModel::CQTOpenGLObjModel(const std::string& str_mtl, const std::string& str_obj) {
+      QString qstrMaterials = QString::fromStdString(str_mtl);
+      QString qstrGeometry = QString::fromStdString(str_obj);
+      /* create a default material */
+      m_mapMaterials["__default_material"];
+      /* load materials */
+      QTextStream cMaterialStream(&qstrMaterials);
+      ImportMaterials(cMaterialStream);
+      /* load geometry */
+      QTextStream cGeometryStream(&qstrGeometry);
+      ImportGeometry(cGeometryStream);
+      /* build the meshes */
+      BuildMeshes();
+      /* check if normals have been provided */
+      if (m_vecNormals.empty()) {
+         THROW_ARGOSEXCEPTION("Error loading model: model does not specify normals.")
+      }
+      /* generate the OpenGL vectors */
+      GenerateOpenGLVectors();
+   }
+
+   /****************************************/
+   /****************************************/
+
    CQTOpenGLObjModel::SMaterial& CQTOpenGLObjModel::GetMaterial(const std::string& str_material) {
       auto tIter = m_mapMaterials.find(str_material);
       if(tIter == std::end(m_mapMaterials)) {

--- a/src/plugins/simulator/visualizations/qt-opengl/qtopengl_obj_model.h
+++ b/src/plugins/simulator/visualizations/qt-opengl/qtopengl_obj_model.h
@@ -55,6 +55,8 @@ namespace argos {
 
       CQTOpenGLObjModel(const std::string& str_model);
 
+      CQTOpenGLObjModel(const std::string& str_mtl, const std::string& str_obj);
+
       SMaterial& GetMaterial(const std::string& str_material);
 
       void Draw() const;


### PR DESCRIPTION
This new constructor allows providing the OBJ and MTL data using `std::string`s. This is useful in cases where robot models are not (or cannot be) installed in the default directories.