### PR TITLE
Remove extension modules from Pi-Puck

### DIFF
--- a/src/plugins/robots/pi-puck/simulator/dynamics3d_pipuck_model.h
+++ b/src/plugins/robots/pi-puck/simulator/dynamics3d_pipuck_model.h
@@ -50,28 +50,30 @@ namespace argos {
       std::shared_ptr<CLink> m_ptrRightWheel;
       /* entities */
       CPiPuckDifferentialDriveEntity& m_cDifferentialDriveEntity;
-      /* lower base data */
-      static const btVector3 m_cBodyHalfExtents;
-      static const btScalar m_fBodyMass;
-      static const btTransform m_cBodyOffset;
-      static const btTransform m_cBodyGeometricOffset;
+      /* body data */
+      static const btScalar BODY_DISTANCE_FROM_FLOOR;
+      static const btVector3 BODY_HALF_EXTENTS;
+      static const btScalar BODY_MASS;
+      static const btTransform BODY_OFFSET;
+      static const btTransform BODY_GEOMETRIC_OFFSET;
       /* wheel data */
-      static const btVector3 m_cWheelHalfExtents;
-      static const btScalar m_fWheelMass;
-      static const btTransform m_cWheelGeometricOffset;
-      static const btTransform m_cLeftWheelOffset;
-      static const btTransform m_cRightWheelOffset;
-      static const btVector3 m_cBodyToRightWheelJointOffset;
-      static const btVector3 m_cRightWheelToBodyJointOffset;
-      static const btQuaternion m_cBodyToRightWheelJointRotation;
-      static const btVector3 m_cBodyToLeftWheelJointOffset;
-      static const btVector3 m_cLeftWheelToBodyJointOffset;
-      static const btQuaternion m_cBodyToLeftWheelJointRotation;
-      static const btScalar m_fBodyFriction;
-      static const btScalar m_fWheelMotorMaxImpulse;
-      static const btScalar m_fWheelFriction;
-      static const btScalar m_fWheelMotorClamp;
-      static const btScalar m_fWheelMotorKdCoefficient;
+      static const btScalar WHEEL_DISTANCE_BETWEEN;
+      static const btVector3 WHEEL_HALF_EXTENTS;
+      static const btScalar WHEEL_MASS;
+      static const btTransform WHEEL_GEOMETRIC_OFFSET;
+      static const btTransform WHEEL_OFFSET_LEFT;
+      static const btTransform WHEEL_OFFSET_RIGHT;
+      static const btVector3 BODY_TO_WHEEL_RIGHT_JOINT_OFFSET;
+      static const btVector3 WHEEL_RIGHT_TO_BODY_JOINT_OFFSET;
+      static const btQuaternion BODY_TO_WHEEL_RIGHT_JOINT_ROTATION;
+      static const btVector3 BODY_TO_WHEEL_LEFT_JOINT_OFFSET;
+      static const btVector3 WHEEL_LEFT_TO_BODY_JOINT_OFFSET;
+      static const btQuaternion BODY_TO_WHEEL_LEFT_JOINT_ROTATION;
+      static const btScalar BODY_FRICTION;
+      static const btScalar WHEEL_MOTOR_MAX_IMPULSE;
+      static const btScalar WHEEL_FRICTION;
+      static const btScalar WHEEL_MOTOR_CLAMP;
+      static const btScalar WHEEL_MOTOR_KD_COEFFICIENT;
    };
 }
 

--- a/src/plugins/robots/pi-puck/simulator/pipuck_entity.cpp
+++ b/src/plugins/robots/pi-puck/simulator/pipuck_entity.cpp
@@ -13,10 +13,8 @@
 
 #include <argos3/plugins/simulator/entities/directional_led_equipped_entity.h>
 #include <argos3/plugins/simulator/entities/radio_equipped_entity.h>
-#include <argos3/plugins/simulator/entities/tag_equipped_entity.h>
 #include <argos3/plugins/simulator/media/directional_led_medium.h>
 #include <argos3/plugins/simulator/media/radio_medium.h>
-#include <argos3/plugins/simulator/media/tag_medium.h>
 
 #include <argos3/plugins/robots/pi-puck/simulator/pipuck_differential_drive_entity.h>
 
@@ -25,9 +23,7 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-   const CVector3 CPiPuckEntity::TAG_OFFSET_POSITION = {0.0, 0.0, 0.1385};
    const CVector3 CPiPuckEntity::WIFI_OFFSET_POSITION = {0.0, 0.0, 0.05};
-   const Real CPiPuckEntity::TAG_SIDE_LENGTH = 0.0235;
    const Real CPiPuckEntity::WIFI_TRANSMISSION_RANGE = 10.0;
 
    /****************************************/
@@ -39,7 +35,6 @@ namespace argos {
                                 const CQuaternion& c_orientation,
                                 bool b_debug,
                                 const std::string& str_wifi_medium,
-                                const std::string& str_tag_medium,
                                 const std::string& str_led_medium) :
       CComposableEntity(nullptr, str_id),
       m_pcControllableEntity(nullptr),
@@ -67,22 +62,6 @@ namespace argos {
          = new CPiPuckDifferentialDriveEntity(this, "differential_drive_0");
       AddComponent(*m_pcDifferentialDriveEntity);
       m_pcDifferentialDriveEntity->Enable();
-      /* create and initialize the tags */
-      m_pcTagEquippedEntity = new CTagEquippedEntity(this, "tags_0");
-      m_pcTagEquippedEntity->AddTag("tag_0",
-                                    TAG_OFFSET_POSITION,
-                                    CQuaternion(),
-                                    m_pcEmbodiedEntity->GetOriginAnchor(),
-                                    CRadians::PI_OVER_THREE,
-                                    TAG_SIDE_LENGTH,
-                                    GetId());
-      if(!str_tag_medium.empty()) {
-         CTagMedium& cTagMedium =
-            CSimulator::GetInstance().GetMedium<CTagMedium>(str_tag_medium);
-         m_pcTagEquippedEntity->SetMedium(cTagMedium);
-         m_pcTagEquippedEntity->Enable();
-      }
-      AddComponent(*m_pcTagEquippedEntity);
       /* create and initialize a radio equipped entity for WiFi */
       m_pcRadioEquippedEntity = new CRadioEquippedEntity(this, "radios_0");
       if(!str_wifi_medium.empty()) {
@@ -204,24 +183,6 @@ namespace argos {
             = new CPiPuckDifferentialDriveEntity(this, "differential_drive_0");
          AddComponent(*m_pcDifferentialDriveEntity);
          m_pcDifferentialDriveEntity->Enable();
-         /* create and initialize the tags */
-         m_pcTagEquippedEntity = new CTagEquippedEntity(this, "tags_0");
-         m_pcTagEquippedEntity->AddTag("tag_0",
-                                       TAG_OFFSET_POSITION,
-                                       CQuaternion(),
-                                       m_pcEmbodiedEntity->GetOriginAnchor(),
-                                       CRadians::PI_OVER_THREE,
-                                       TAG_SIDE_LENGTH,
-                                       GetId());
-         std::string strTagMedium;
-         GetNodeAttributeOrDefault(t_tree, "tag_medium", strTagMedium, strTagMedium);
-         if(!strTagMedium.empty()) {
-            CTagMedium& cTagMedium =
-               CSimulator::GetInstance().GetMedium<CTagMedium>(strTagMedium);
-            m_pcTagEquippedEntity->SetMedium(cTagMedium);
-            m_pcTagEquippedEntity->Enable();
-         }
-         AddComponent(*m_pcTagEquippedEntity);
          /* create and initialize a radio equipped entity for the wifi */
          m_pcRadioEquippedEntity = new CRadioEquippedEntity(this, "radios_0");
          std::string strWifiMedium;

--- a/src/plugins/robots/pi-puck/simulator/pipuck_entity.h
+++ b/src/plugins/robots/pi-puck/simulator/pipuck_entity.h
@@ -13,7 +13,6 @@ namespace argos {
    class CDirectionalLEDEquippedEntity;
    class CEmbodiedEntity;
    class CRadioEquippedEntity;
-   class CTagEquippedEntity;
 }
 
 #include <argos3/core/simulator/entity/composable_entity.h>
@@ -34,7 +33,6 @@ namespace argos {
          m_pcEmbodiedEntity(nullptr),
          m_pcDifferentialDriveEntity(nullptr),
          m_pcRadioEquippedEntity(nullptr),
-         m_pcTagEquippedEntity(nullptr),
          m_bDebug(false) {}
 
       CPiPuckEntity(const std::string& str_id,
@@ -43,7 +41,6 @@ namespace argos {
                     const CQuaternion& c_orientation,
                     bool b_debug = false,
                     const std::string& str_wifi_medium = "",
-                    const std::string& str_tag_medium = "",
                     const std::string& str_led_medium = "");
 
       virtual ~CPiPuckEntity() {}
@@ -90,14 +87,6 @@ namespace argos {
          return *m_pcRadioEquippedEntity;
       }
 
-      inline CTagEquippedEntity& GetTagEquippedEntity() {
-         return *m_pcTagEquippedEntity;
-      }
-
-      inline const CTagEquippedEntity& GetTagEquippedEntity() const {
-         return *m_pcTagEquippedEntity;
-      }
-
       inline bool IsDebug() const {
          return m_bDebug;
       }
@@ -111,13 +100,10 @@ namespace argos {
       CEmbodiedEntity*                m_pcEmbodiedEntity;
       CPiPuckDifferentialDriveEntity* m_pcDifferentialDriveEntity;
       CRadioEquippedEntity*           m_pcRadioEquippedEntity;
-      CTagEquippedEntity*             m_pcTagEquippedEntity;
 
       bool m_bDebug;
 
-      static const CVector3 TAG_OFFSET_POSITION;
       static const CVector3 WIFI_OFFSET_POSITION;
-      static const Real     TAG_SIDE_LENGTH;
       static const Real     WIFI_TRANSMISSION_RANGE;
    };
 

--- a/src/plugins/robots/pi-puck/simulator/qtopengl_pipuck.cpp
+++ b/src/plugins/robots/pi-puck/simulator/qtopengl_pipuck.cpp
@@ -10,7 +10,6 @@
 #include <argos3/core/utility/math/vector2.h>
 #include <argos3/plugins/robots/pi-puck/simulator/pipuck_entity.h>
 #include <argos3/plugins/simulator/entities/directional_led_equipped_entity.h>
-#include <argos3/plugins/simulator/entities/tag_equipped_entity.h>
 #include <argos3/plugins/simulator/visualizations/qt-opengl/qtopengl_widget.h>
 
 #include <array>
@@ -39,33 +38,6 @@ namespace argos {
       },
       m_sBodyLED(m_cPiPuckModel.GetMaterial("Green-Body-LEDs")),
       m_sFrontLED(m_cPiPuckModel.GetMaterial("Front-facing-Red-LED")) {
-      /* generate the tag texture */
-      GLuint unTagTex;
-      glGenTextures(1, &unTagTex);
-      glBindTexture(GL_TEXTURE_2D, unTagTex);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 10, 10, 0, GL_RGB, GL_FLOAT, m_arrTagTexture.data());
-      /* draw normalized tag into list */
-      m_unTagList = glGenLists(1);
-      glNewList(m_unTagList, GL_COMPILE);
-      glEnable(GL_NORMALIZE);
-      glDisable(GL_LIGHTING);
-      glEnable(GL_TEXTURE_2D);
-      glBindTexture(GL_TEXTURE_2D, unTagTex);
-      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-      glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-      glBegin(GL_QUADS);
-      glNormal3f(0.0f, 0.0f, 1.0f);
-      glTexCoord2f(1.0f, 1.0f); glVertex2f( 0.5f,  0.5f);
-      glTexCoord2f(0.0f, 1.0f); glVertex2f(-0.5f,  0.5f);
-      glTexCoord2f(0.0f, 0.0f); glVertex2f(-0.5f, -0.5f);
-      glTexCoord2f(1.0f, 0.0f); glVertex2f( 0.5f, -0.5f);
-      glEnd();
-      glDisable(GL_TEXTURE_2D);
-      glEnable(GL_LIGHTING);
-      glDisable(GL_NORMALIZE);
-      glEndList();
    }
 
    /****************************************/
@@ -119,26 +91,6 @@ namespace argos {
       glRotatef(ToDegrees(cYAngle).GetValue(), 0.0f, 1.0f, 0.0f);
       glRotatef(ToDegrees(cZAngle).GetValue(), 0.0f, 0.0f, 1.0f);
       m_cPiPuckModel.Draw();
-      /* draw tags */
-      for(const CTagEquippedEntity::SInstance& s_instance :
-          c_entity.GetTagEquippedEntity().GetInstances()) {
-         /* the texture of the tag contains the white border which isn't actually part
-            of the tag. Stretching the texture by 25% fixes this problem */
-         Real fScaling = s_instance.Tag.GetSideLength() * 1.25f;
-         const CVector3& cTagPosition = s_instance.PositionOffset;
-         const CQuaternion& cTagOrientation = s_instance.OrientationOffset;
-         cTagOrientation.ToEulerAngles(cZAngle, cYAngle, cXAngle);
-         glPushMatrix();
-         glTranslatef(cTagPosition.GetX(),
-                      cTagPosition.GetY(),
-                      cTagPosition.GetZ());
-         glRotatef(ToDegrees(cXAngle).GetValue(), 1.0f, 0.0f, 0.0f);
-         glRotatef(ToDegrees(cYAngle).GetValue(), 0.0f, 1.0f, 0.0f);
-         glRotatef(ToDegrees(cZAngle).GetValue(), 0.0f, 0.0f, 1.0f);
-         glScalef(fScaling, fScaling, 1.0f);
-         glCallList(m_unTagList);
-         glPopMatrix();
-      }
       glPopMatrix();
       /* draw the left wheel */
       const SAnchor& sLeftWheelAnchor = c_entity.GetEmbodiedEntity().GetAnchor("left_wheel");
@@ -298,22 +250,6 @@ namespace argos {
 
    /****************************************/
    /****************************************/
-
-#define TAG_WHITE std::array<GLfloat, 3> {1.0f, 1.0f, 1.0f}
-#define TAG_BLACK std::array<GLfloat, 3> {0.0f, 0.0f, 0.0f}
-
-   const std::array<std::array<GLfloat, 3>, 100> CQTOpenGLPiPuck::m_arrTagTexture {
-      TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_BLACK, TAG_WHITE, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_WHITE, TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_WHITE, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_BLACK, TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_BLACK, TAG_WHITE,
-      TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE, TAG_WHITE,
-   };
 
    const std::array<GLfloat, 4> CQTOpenGLPiPuck::m_arrRingLedOffAmbientDiffuse  {0.75f, 0.75f, 0.75f, 0.8f};
    const std::array<GLfloat, 4> CQTOpenGLPiPuck::m_arrRingLedOnAmbientDiffuse   {1.00f, 0.00f, 0.00f, 0.8f};


### PR DESCRIPTION
This PR removes the tag holder, omni-directional camera, and range and bearing board from the model. The default model shall only provide the most minimal configuration with extensions handled via external plugins.