### PR TITLE
Rename and update the Pi-Puck's front camera sensor

### DIFF
--- a/src/plugins/robots/pi-puck/CMakeLists.txt
+++ b/src/plugins/robots/pi-puck/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # argos3/plugins/robots/pi-puck/control_interface
 set(ARGOS3_HEADERS_PLUGINS_ROBOTS_PIPUCK_CONTROLINTERFACE
-  control_interface/ci_pipuck_camera_system_sensor.h
+  control_interface/ci_pipuck_front_camera_sensor.h
   control_interface/ci_pipuck_differential_drive_actuator.h
   control_interface/ci_pipuck_differential_drive_sensor.h
   control_interface/ci_pipuck_ground_sensor.h
@@ -16,7 +16,7 @@ if(ARGOS_BUILD_FOR_SIMULATOR)
   set(ARGOS3_HEADERS_PLUGINS_ROBOTS_PIPUCK_SIMULATOR
     simulator/dynamics2d_pipuck_model.h
     simulator/dynamics3d_pipuck_model.h
-    simulator/pipuck_camera_system_default_sensor.h
+    simulator/pipuck_front_camera_default_sensor.h
     simulator/pipuck_differential_drive_default_actuator.h
     simulator/pipuck_differential_drive_default_sensor.h
     simulator/pipuck_differential_drive_entity.h
@@ -40,7 +40,7 @@ endif(ARGOS_BUILD_FOR_SIMULATOR)
 # argos3/plugins/robots/pi-puck/control_interface
 set(ARGOS3_SOURCES_PLUGINS_ROBOTS_PIPUCK
   ${ARGOS3_HEADERS_PLUGINS_ROBOTS_PIPUCK_CONTROLINTERFACE}
-  control_interface/ci_pipuck_camera_system_sensor.cpp
+  control_interface/ci_pipuck_front_camera_sensor.cpp
   control_interface/ci_pipuck_differential_drive_actuator.cpp
   control_interface/ci_pipuck_differential_drive_sensor.cpp
   control_interface/ci_pipuck_ground_sensor.cpp
@@ -55,7 +55,7 @@ if(ARGOS_BUILD_FOR_SIMULATOR)
     ${ARGOS3_HEADERS_PLUGINS_ROBOTS_PIPUCK_SIMULATOR}
     simulator/dynamics2d_pipuck_model.cpp
     simulator/dynamics3d_pipuck_model.cpp
-    simulator/pipuck_camera_system_default_sensor.cpp
+    simulator/pipuck_front_camera_default_sensor.cpp
     simulator/pipuck_differential_drive_default_actuator.cpp
     simulator/pipuck_differential_drive_default_sensor.cpp
     simulator/pipuck_differential_drive_entity.cpp

--- a/src/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.cpp
+++ b/src/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.cpp
@@ -1,10 +1,10 @@
 /**
- * @file <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_camera_system_sensor.cpp>
+ * @file <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.cpp>
  *
  * @author Michael Allwright <allsey87@gmail.com>
  */
 
-#include "ci_pipuck_camera_system_sensor.h"
+#include "ci_pipuck_front_camera_sensor.h"
 
 #ifdef ARGOS_WITH_LUA
 #include <argos3/core/wrappers/lua/lua_utility.h>
@@ -17,14 +17,14 @@ namespace argos {
    /****************************************/
 
 #ifdef ARGOS_WITH_LUA
-   int LuaEnablePiPuckCameraSystemSensor(lua_State* pt_lua_state) {
+   int LuaEnablePiPuckFrontCameraSensor(lua_State* pt_lua_state) {
       /* Check parameters */
       if(lua_gettop(pt_lua_state) != 0) {
-         return luaL_error(pt_lua_state, "robot.camera_system.enable() expects zero arguments");
+         return luaL_error(pt_lua_state, "robot.front_camera.enable() expects zero arguments");
       }
       /* Get the camera sensor */
-      CCI_PiPuckCameraSystemSensor* pcCameraSensor = 
-         CLuaUtility::GetDeviceInstance<CCI_PiPuckCameraSystemSensor>(pt_lua_state, "camera_system");
+      CCI_PiPuckFrontCameraSensor* pcCameraSensor = 
+         CLuaUtility::GetDeviceInstance<CCI_PiPuckFrontCameraSensor>(pt_lua_state, "front_camera");
       /* Set the enable member */
       pcCameraSensor->Enable();
       return 0;
@@ -35,14 +35,14 @@ namespace argos {
    /****************************************/
 
 #ifdef ARGOS_WITH_LUA
-   int LuaDisablePiPuckCameraSystemSensor(lua_State* pt_lua_state) {
+   int LuaDisablePiPuckFrontCameraSensor(lua_State* pt_lua_state) {
       /* Check parameters */
       if(lua_gettop(pt_lua_state) != 0) {
-         return luaL_error(pt_lua_state, "robot.camera_system.disable() expects zero arguments");
+         return luaL_error(pt_lua_state, "robot.front_camera.disable() expects zero arguments");
       }
       /* Get the camera sensor */
-      CCI_PiPuckCameraSystemSensor* pcCameraSensor = 
-         CLuaUtility::GetDeviceInstance<CCI_PiPuckCameraSystemSensor>(pt_lua_state, "camera_system");
+      CCI_PiPuckFrontCameraSensor* pcCameraSensor = 
+         CLuaUtility::GetDeviceInstance<CCI_PiPuckFrontCameraSensor>(pt_lua_state, "front_camera");
       /* Set the enable member */
       pcCameraSensor->Disable();
       return 0;
@@ -57,17 +57,17 @@ namespace argos {
     * the stack must contain a single table with keys named x, y, and z
     * which represent the X, Y, and Z components of a 3D vector
     */
-   int LuaPiPuckCameraSystemSensorDetectLed(lua_State* pt_lua_state) {
+   int LuaPiPuckFrontCameraSensorDetectLed(lua_State* pt_lua_state) {
       /* check parameters */
       if(lua_gettop(pt_lua_state) != 1) {
-         return luaL_error(pt_lua_state, "robot.camera_system.detect_led() expects a single argument");
+         return luaL_error(pt_lua_state, "robot.front_camera.detect_led() expects a single argument");
       }
       const CVector3& cPosition = CLuaVector3::ToVector3(pt_lua_state, 1);
       /* get the camera sensor */
-      CCI_PiPuckCameraSystemSensor* pcCameraSensor = 
-         CLuaUtility::GetDeviceInstance<CCI_PiPuckCameraSystemSensor>(pt_lua_state, "camera_system");
+      CCI_PiPuckFrontCameraSensor* pcCameraSensor = 
+         CLuaUtility::GetDeviceInstance<CCI_PiPuckFrontCameraSensor>(pt_lua_state, "front_camera");
       /* get the LED state */
-      const CCI_PiPuckCameraSystemSensor::ELedState& eLedState =
+      const CCI_PiPuckFrontCameraSensor::ELedState& eLedState =
          pcCameraSensor->DetectLed(cPosition);
       /* convert the LED state to an integer and push it onto the stack */
       lua_pushinteger(pt_lua_state, static_cast<UInt8>(eLedState));
@@ -80,18 +80,18 @@ namespace argos {
    /****************************************/
 
 #ifdef ARGOS_WITH_LUA
-   void CCI_PiPuckCameraSystemSensor::CreateLuaState(lua_State* pt_lua_state) {
-      CLuaUtility::OpenRobotStateTable(pt_lua_state, "camera_system");
+   void CCI_PiPuckFrontCameraSensor::CreateLuaState(lua_State* pt_lua_state) {
+      CLuaUtility::OpenRobotStateTable(pt_lua_state, "front_camera");
       CLuaUtility::AddToTable(pt_lua_state, "_instance", this);
       CLuaUtility::AddToTable(pt_lua_state,
                               "enable",
-                              &LuaEnablePiPuckCameraSystemSensor);
+                              &LuaEnablePiPuckFrontCameraSensor);
       CLuaUtility::AddToTable(pt_lua_state,
                               "disable",
-                              &LuaDisablePiPuckCameraSystemSensor);
+                              &LuaDisablePiPuckFrontCameraSensor);
       CLuaUtility::AddToTable(pt_lua_state,
                               "detect_led",
-                              &LuaPiPuckCameraSystemSensorDetectLed);
+                              &LuaPiPuckFrontCameraSensorDetectLed);
       CLuaUtility::AddToTable(pt_lua_state, "timestamp", 0.0f);
       CLuaUtility::StartTable(pt_lua_state, "tags");
       for(size_t i = 0; i < m_tTags.size(); ++i) {
@@ -111,11 +111,11 @@ namespace argos {
       }
       CLuaUtility::EndTable(pt_lua_state);
       CLuaUtility::StartTable(pt_lua_state, "transform");
-      CLuaUtility::AddToTable(pt_lua_state, "position", m_cOffsetPosition);
-      CLuaUtility::AddToTable(pt_lua_state, "orientation", m_cOffsetOrientation);
-      CLuaUtility::AddToTable(pt_lua_state, "anchor", m_strAnchor);
+      CLuaUtility::AddToTable(pt_lua_state, "position", CAMERA_POSITION_OFFSET);
+      CLuaUtility::AddToTable(pt_lua_state, "orientation", CAMERA_ORIENTATION_OFFSET);
+      CLuaUtility::AddToTable(pt_lua_state, "anchor", CAMERA_ANCHOR);
       CLuaUtility::EndTable(pt_lua_state);
-      CLuaUtility::AddToTable(pt_lua_state, "resolution", m_cResolution);
+      CLuaUtility::AddToTable(pt_lua_state, "resolution", CAMERA_RESOLUTION);
       CLuaUtility::CloseRobotStateTable(pt_lua_state);
    }
 #endif
@@ -123,13 +123,9 @@ namespace argos {
    /****************************************/
    /****************************************/
 
-
-
-
-
 #ifdef ARGOS_WITH_LUA
-   void CCI_PiPuckCameraSystemSensor::ReadingsToLuaState(lua_State* pt_lua_state) {
-      lua_getfield(pt_lua_state, -1, "camera_system");
+   void CCI_PiPuckFrontCameraSensor::ReadingsToLuaState(lua_State* pt_lua_state) {
+      lua_getfield(pt_lua_state, -1, "front_camera");
       CLuaUtility::AddToTable(pt_lua_state, "timestamp", m_fTimestamp);
       lua_getfield(pt_lua_state, -1, "tags");
       /* get the tag count from last time */
@@ -161,6 +157,17 @@ namespace argos {
       lua_pop(pt_lua_state, 1);
    }
 #endif
+
+   /****************************************/
+   /****************************************/
+   
+   const CVector3 CCI_PiPuckFrontCameraSensor::CAMERA_POSITION_OFFSET = CVector3(0.0363, 0.0, 0.0275);
+   const CQuaternion CCI_PiPuckFrontCameraSensor::CAMERA_ORIENTATION_OFFSET = CQuaternion(CRadians::PI_OVER_TWO, CVector3::Y);
+   const CVector2 CCI_PiPuckFrontCameraSensor::CAMERA_RESOLUTION = CVector2(480.0, 640.0);
+   // TODO: CALIBRATE THESE CONSTANTS
+   const CVector2 CCI_PiPuckFrontCameraSensor::CAMERA_FOCAL_LENGTH = CVector2(1040.0, 1040.0);
+   const CVector2 CCI_PiPuckFrontCameraSensor::CAMERA_PRINCIPAL_POINT = CVector2(240.0, 320.0);
+   const std::string CCI_PiPuckFrontCameraSensor::CAMERA_ANCHOR = "origin";
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.h
+++ b/src/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.h
@@ -1,14 +1,14 @@
 /**
- * @file <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_camera_system_sensor.h>
+ * @file <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.h>
  *
  * @author Michael Allwright <allsey87@gmail.com>
  */
 
-#ifndef CCI_PIPUCK_CAMERA_SYSTEM_SENSOR_H
-#define CCI_PIPUCK_CAMERA_SYSTEM_SENSOR_H
+#ifndef CCI_PIPUCK_FRONT_CAMERA_SENSOR_H
+#define CCI_PIPUCK_FRONT_CAMERA_SENSOR_H
 
 namespace argos {
-   class CCI_PiPuckCameraSystemSensor;
+   class CCI_PiPuckFrontCameraSensor;
 }
 
 #include <argos3/core/control_interface/ci_sensor.h>
@@ -18,7 +18,7 @@ namespace argos {
 
 namespace argos {
 
-   class CCI_PiPuckCameraSystemSensor : public CCI_Sensor {
+   class CCI_PiPuckFrontCameraSensor : public CCI_Sensor {
 
    public:
 
@@ -53,12 +53,14 @@ namespace argos {
          using TVector = std::vector<STag>;
       };
 
+      using TConfiguration = std::tuple<const char*, CVector3, CQuaternion>;
+
    public:
 
-      CCI_PiPuckCameraSystemSensor() :
+      CCI_PiPuckFrontCameraSensor() :
          m_bEnabled(false) {}
 
-      virtual ~CCI_PiPuckCameraSystemSensor() {}
+      virtual ~CCI_PiPuckFrontCameraSensor() {}
 
       virtual void Reset() {
          /* clear the readings */
@@ -100,10 +102,12 @@ namespace argos {
       /* the timestamp of the current frame */
       Real m_fTimestamp;
       /* the position, orientation, and anchor of the camera sensor */
-      CVector2 m_cResolution;
-      CVector3 m_cOffsetPosition;
-      CQuaternion m_cOffsetOrientation;
-      std::string m_strAnchor;
+      static const CVector3 CAMERA_POSITION_OFFSET;
+      static const CQuaternion CAMERA_ORIENTATION_OFFSET;
+      static const CVector2 CAMERA_RESOLUTION;
+      static const CVector2 CAMERA_FOCAL_LENGTH;
+      static const CVector2 CAMERA_PRINCIPAL_POINT;
+      static const std::string CAMERA_ANCHOR;
 
    };
 

--- a/src/plugins/robots/pi-puck/simulator/pipuck_front_camera_default_sensor.h
+++ b/src/plugins/robots/pi-puck/simulator/pipuck_front_camera_default_sensor.h
@@ -1,11 +1,11 @@
 /**
- * @file <argos3/plugins/robots/pi-puck/simulator/pipuck_camera_system_default_sensor.h>
+ * @file <argos3/plugins/robots/pi-puck/simulator/pipuck_front_camera_default_sensor.h>
  *
  * @author Michael Allwright - <allsey87@gmail.com>
  */
 
-#ifndef PIPUCK_CAMERA_SYSTEM_DEFAULT_SENSOR_H
-#define PIPUCK_CAMERA_SYSTEM_DEFAULT_SENSOR_H
+#ifndef PIPUCK_FRONT_CAMERA_DEFAULT_SENSOR_H
+#define PIPUCK_FRONT_CAMERA_DEFAULT_SENSOR_H
 
 namespace argos {
    class CEmbodiedEntity;
@@ -23,17 +23,17 @@ namespace argos {
 
 #include <argos3/plugins/simulator/entities/tag_entity.h>
 #include <argos3/plugins/simulator/entities/directional_led_entity.h>
-#include <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_camera_system_sensor.h>
+#include <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.h>
 
 #include <vector>
 #include <array>
 
 namespace argos {
 
-   class CPiPuckCameraSystemDefaultSensor : public CSimulatedSensor,
-                                            public CCI_PiPuckCameraSystemSensor,
-                                            public CPositionalIndex<CTagEntity>::COperation,
-                                            public CPositionalIndex<CDirectionalLEDEntity>::COperation {
+   class CPiPuckFrontCameraDefaultSensor : public CSimulatedSensor,
+                                           public CCI_PiPuckFrontCameraSensor,
+                                           public CPositionalIndex<CTagEntity>::COperation,
+                                           public CPositionalIndex<CDirectionalLEDEntity>::COperation {
 
    public:
 
@@ -52,9 +52,9 @@ namespace argos {
 
    public:
 
-      CPiPuckCameraSystemDefaultSensor();
+      CPiPuckFrontCameraDefaultSensor();
 
-      virtual ~CPiPuckCameraSystemDefaultSensor() {}
+      virtual ~CPiPuckFrontCameraDefaultSensor() {}
 
       virtual void SetRobot(CComposableEntity& c_entity);
 
@@ -87,7 +87,6 @@ namespace argos {
    private:
       CControllableEntity* m_pcControllableEntity;
       CEmbodiedEntity* m_pcEmbodiedEntity;
-      SAnchor* m_psEndEffectorAnchor;
       CPositionalIndex<CDirectionalLEDEntity>* m_pcDirectionalLEDIndex;
       CPositionalIndex<CTagEntity>* m_pcTagIndex;
 

--- a/src/testing/pi-puck/CMakeLists.txt
+++ b/src/testing/pi-puck/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(drive_forward_dynamics3d)
 add_subdirectory(drive_forward_dynamics2d)
-
+add_subdirectory(front_camera_tags_leds)

--- a/src/testing/pi-puck/front_camera_tags_leds/CMakeLists.txt
+++ b/src/testing/pi-puck/front_camera_tags_leds/CMakeLists.txt
@@ -1,0 +1,26 @@
+# compile test loop functions
+add_library(pipuck_front_camera_tags_leds_loop_functions MODULE
+  loop_functions.h
+  loop_functions.cpp)
+target_link_libraries(pipuck_front_camera_tags_leds_loop_functions
+    argos3core_${ARGOS_BUILD_FOR}
+    argos3plugin_${ARGOS_BUILD_FOR}_pipuck)
+# compile test controller
+add_library(pipuck_front_camera_tags_leds_controller MODULE
+  controller.h
+  controller.cpp)
+target_link_libraries(pipuck_front_camera_tags_leds_controller
+    argos3core_${ARGOS_BUILD_FOR}
+    argos3plugin_${ARGOS_BUILD_FOR}_pipuck)
+# configure experiment
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/configuration.argos.in
+  ${CMAKE_CURRENT_BINARY_DIR}/configuration.argos)
+# define test
+add_test(
+   NAME pipuck_front_camera_tags_leds
+   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+   COMMAND argos3 -zc configuration.argos)
+set_tests_properties(pipuck_front_camera_tags_leds
+  PROPERTIES ENVIRONMENT "ARGOS_PLUGIN_PATH=${ARGOS_PLUGIN_PATH}")
+

--- a/src/testing/pi-puck/front_camera_tags_leds/configuration.argos.in
+++ b/src/testing/pi-puck/front_camera_tags_leds/configuration.argos.in
@@ -1,0 +1,74 @@
+<?xml version="1.0" ?>
+<argos-configuration>
+
+  <!-- ************************* -->
+  <!-- * General configuration * -->
+  <!-- ************************* -->
+  <framework>
+    <system threads="0" />
+    <experiment length="0" ticks_per_second="10" random_seed="0" />
+  </framework>
+  
+  <!-- *************** -->
+  <!-- * Controllers * -->
+  <!-- *************** -->
+  <controllers>
+    <test_controller library="@CMAKE_CURRENT_BINARY_DIR@/libpipuck_front_camera_tags_leds_controller"
+                     id="test_controller">
+      <actuators />
+      <sensors>
+        <pipuck_front_camera implementation="default" show_tag_rays="true" />
+      </sensors>
+      <params />
+    </test_controller>
+    <lua_controller id="x"> <!-- remove -->
+      <actuators />
+      <sensors />
+      <params />
+    </lua_controller>
+  </controllers>
+
+  <!-- ****************** -->
+  <!-- * Loop functions * -->
+  <!-- ****************** -->
+  <loop_functions library="@CMAKE_CURRENT_BINARY_DIR@/libpipuck_front_camera_tags_leds_loop_functions"
+                  label="test_loop_functions" />
+
+  <!-- *********************** -->
+  <!-- * Arena configuration * -->
+  <!-- *********************** -->
+  <arena size="1, 1, 1" positional_index="grid" positional_grid_size="5,5,1">
+    <pipuck id="pipuck">
+      <body position="0,0,0" orientation="0,0,0"/>
+      <controller config="test_controller"/>
+    </pipuck>
+    <block id="block" init_led_color="green">
+      <body position="0.25,0,0" orientation="0,0,0"/>
+      <controller config="x"/> <!-- remove -->
+    </block>
+  </arena>
+
+  <!-- ******************* -->
+  <!-- * Physics engines * -->
+  <!-- ******************* -->
+  <physics_engines>
+    <dynamics3d id="dyn3d" />
+  </physics_engines>
+
+  <!-- ********* -->
+  <!-- * Media * -->
+  <!-- ********* -->
+  <media>
+    <tag id="tags" index="grid" grid_size="5,5,5" />
+    <directional_led id="directional_leds" index="grid" grid_size="5,5,5" />
+    <simple_radio id="nfc" index="grid" grid_size="5,5,5" /> <!-- remove -->
+  </media>
+
+  <!-- ****************** -->
+  <!-- * Visualization * -->
+  <!-- ****************** -->
+  <visualization>
+    <qt-opengl show_boundary="false"/>
+  </visualization>
+
+</argos-configuration>

--- a/src/testing/pi-puck/front_camera_tags_leds/controller.cpp
+++ b/src/testing/pi-puck/front_camera_tags_leds/controller.cpp
@@ -1,0 +1,35 @@
+/**
+ *
+ * @author Michael Allwright <mallwright@learnrobotics.io>
+ */
+
+#include "controller.h"
+
+#include <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.h>
+
+namespace argos {
+
+   /****************************************/
+   /****************************************/
+
+   void CTestController::Init(TConfigurationNode& t_tree) {
+      m_pcFrontCameraSensor = GetSensor<CCI_PiPuckFrontCameraSensor>("pipuck_front_camera");
+      Reset();
+   }
+
+   /****************************************/
+   /****************************************/
+
+   void CTestController::Reset() {
+      m_pcFrontCameraSensor->Enable();
+   }
+
+   /****************************************/
+   /****************************************/
+
+   REGISTER_CONTROLLER(CTestController, "test_controller");
+
+}
+
+
+

--- a/src/testing/pi-puck/front_camera_tags_leds/controller.h
+++ b/src/testing/pi-puck/front_camera_tags_leds/controller.h
@@ -1,0 +1,30 @@
+/**
+ *
+ * @author Michael Allwright <mallwright@learnrobotics.io>
+ */
+
+namespace argos {
+   class CCI_PiPuckFrontCameraSensor;
+}
+
+#include <argos3/core/control_interface/ci_controller.h>
+
+namespace argos {
+
+   class CTestController : public CCI_Controller {
+
+   public:
+
+      CTestController() {}
+
+      virtual ~CTestController() {}
+
+      virtual void Init(TConfigurationNode& t_tree);
+
+      virtual void Reset();
+
+   private:
+      CCI_PiPuckFrontCameraSensor* m_pcFrontCameraSensor;
+
+   };
+}

--- a/src/testing/pi-puck/front_camera_tags_leds/loop_functions.cpp
+++ b/src/testing/pi-puck/front_camera_tags_leds/loop_functions.cpp
@@ -1,0 +1,54 @@
+#include "loop_functions.h"
+#include <argos3/plugins/robots/pi-puck/simulator/pipuck_entity.h>
+#include <argos3/plugins/robots/pi-puck/control_interface/ci_pipuck_front_camera_sensor.h>
+#include <argos3/core/simulator/entity/embodied_entity.h>
+
+namespace argos {
+
+   /****************************************/
+   /****************************************/
+
+   bool CTestLoopFunctions::IsExperimentFinished() {
+      if(GetSpace().GetSimulationClock() == 0) {
+         return false;
+      }
+      else {
+         CPiPuckEntity* pcPiPuck = nullptr;
+         try {
+            CEntity& cEntity = GetSpace().GetEntity("pipuck");
+            pcPiPuck = dynamic_cast<CPiPuckEntity*>(&cEntity);
+         }
+         catch(CARGoSException& ex) {
+            THROW_ARGOSEXCEPTION_NESTED("Robot was not added to the simulator", ex);
+         }
+         if(pcPiPuck == nullptr) {
+            THROW_ARGOSEXCEPTION("Robot was not a Pi-Puck");
+         }
+         CCI_Controller& cController = pcPiPuck->GetControllableEntity().GetController();
+         CCI_PiPuckFrontCameraSensor& cFrontCamera =
+            *cController.GetSensor<CCI_PiPuckFrontCameraSensor>("pipuck_front_camera");
+         if(cFrontCamera.GetTags().size() != 1) {
+            THROW_ARGOSEXCEPTION("Incorrect number of tags detected");
+         }
+         /* try to detect an LED 2 cm left from the center of the tag. This is a bit of a hack since
+            rotation is ignored, but it is sufficient for testing the simulator */
+         const CVector3& cTagPosition = cFrontCamera.GetTags()[0].Position + LED_OFFSET;
+         if(cFrontCamera.DetectLed(cTagPosition) != CCI_PiPuckFrontCameraSensor::ELedState::Q3) {
+            THROW_ARGOSEXCEPTION("Incorrect LED color detected");
+         }
+         return true;
+      }
+      return false;
+   }
+
+   /****************************************/
+   /****************************************/
+
+   const CVector3 CTestLoopFunctions::LED_OFFSET = CVector3::Y * 0.02;
+
+   /****************************************/
+   /****************************************/
+
+   REGISTER_LOOP_FUNCTIONS(CTestLoopFunctions, "test_loop_functions");
+
+}

--- a/src/testing/pi-puck/front_camera_tags_leds/loop_functions.h
+++ b/src/testing/pi-puck/front_camera_tags_leds/loop_functions.h
@@ -1,0 +1,30 @@
+#ifndef TEST_LOOP_FUNCTIONS_H
+#define TEST_LOOP_FUNCTIONS_H
+
+namespace argos {
+   class CEmbodiedEntity;
+}
+
+#include <argos3/core/simulator/loop_functions.h>
+
+namespace argos {
+
+   class CTestLoopFunctions : public CLoopFunctions {
+
+   public:
+
+      CTestLoopFunctions() {}
+
+      virtual ~CTestLoopFunctions() {}
+
+      virtual bool IsExperimentFinished() override;
+
+   private:
+
+      const static CVector3 LED_OFFSET;
+
+   };
+}
+
+#endif
+


### PR DESCRIPTION
This commit updates the control interface and simulation implementation of the Pi-Puck's front camera. The terminology "camera system" has been dropped in favor of "front camera" since this will make it easier to accomodate 3rd party omnidirectional camera sensors. A simple test that determines whether a tag on a stigmergic block and a nearby LED can be detected has been added.