### PR TITLE
fixed a race condition in simple_radio_entity

### DIFF
--- a/src/plugins/simulator/entities/simple_radio_entity.h
+++ b/src/plugins/simulator/entities/simple_radio_entity.h
@@ -18,6 +18,7 @@ namespace argos {
 #include <argos3/core/utility/datatypes/byte_array.h>
 #include <argos3/core/simulator/space/positional_indices/space_hash.h>
 #include <argos3/core/simulator/space/positional_indices/grid.h>
+#include <mutex>
 
 namespace argos {
 
@@ -75,7 +76,9 @@ namespace argos {
        * @see GetMessages()
        */
       inline void ReceiveMessage(const CVector3& c_origin, const CByteArray& c_message) {
+         m_vecMessages_guard.lock();
          m_vecMessages.emplace_back(c_origin, c_message);
+         m_vecMessages_guard.unlock();
       }
 
       /**
@@ -138,6 +141,7 @@ namespace argos {
       CSimpleRadioMedium* m_pcMedium;
       Real m_fRange;
       std::vector<std::pair<CVector3, CByteArray> > m_vecMessages;
+      std::mutex m_vecMessages_guard;
 
    };
 


### PR DESCRIPTION
Hi all,

I'm new to argos, so when I kept getting strange errors trying to implement linear consensus over the simple_radio I thought it was my bad. But! When the error never happened with just two robots or when running on a single thread, I suspected there may be a bug in the radio plugin. Turns out there's a race con in `ReceiveMessage`, which I have wrapped in guards. I've tested the change in an experiment with hundreds of robots and high average connectivity with 16 threads, and no longer get any weird errors.

I know this is a small change but hopefully saves somebody else a headache