### PR TITLE
Fix ARGoS crashing on exception with --logerr-file

### DIFF
--- a/doc/argos3.1
+++ b/doc/argos3.1
@@ -56,11 +56,11 @@ queries the available plugins.
 \fB\-n\fR, \fB\-\-no-color\fR
 do not use colored output.
 .TP
-\fB\-l \fIFILE\fR, \fB\-\-log\-file=\fIFILE\fR
+\fB\-l \fIFILE\fR, \fB\-\-log\-file \fIFILE\fR
 redirect LOG to
 .IR FILE "."
 .TP
-\fB\-e \fIFILE\fR, \fB\-\-logerr\-file=\fIFILE\fR
+\fB\-e \fIFILE\fR, \fB\-\-logerr\-file \fIFILE\fR
 redirect LOGERR to
 .IR FILE "."
 .SH QUERIES

--- a/src/core/simulator/argos_command_line_arg_parser.cpp
+++ b/src/core/simulator/argos_command_line_arg_parser.cpp
@@ -101,6 +101,8 @@ namespace argos {
          }
          m_pcInitLogStream = LOG.GetStream().rdbuf();
          LOG.GetStream().rdbuf(m_cLogFile.rdbuf());
+         /* Redirect stdout (different than std::cout!) */
+         std::freopen(m_strLogFileName.c_str(), "w", stdout);
       }
       if(m_strLogErrFileName != "") {
          LOGERR.DisableColoredOutput();
@@ -110,7 +112,13 @@ namespace argos {
          }
          m_pcInitLogErrStream = LOGERR.GetStream().rdbuf();
          LOGERR.GetStream().rdbuf(m_cLogErrFile.rdbuf());
+         /*
+          * Redirect stderr (different than std::cerr!). Exceptions print to
+          * here when uncaught, so we need to capture it too.
+          */
+         std::freopen(m_strLogErrFileName.c_str(), "w", stderr);
       }
+
 
       /* Check that either -h, -v, -c or -q was passed (strictly one of them) */
       UInt32 nOptionsOn = 0;


### PR DESCRIPTION
- Apparently std::cerr != stderr, which is where exceptions get printed to.
- Also update manpage