### PR TITLE
Normalize drone orientation errors to [-pi, pi]

### DIFF
--- a/src/plugins/robots/drone/simulator/pointmass3d_drone_model.cpp
+++ b/src/plugins/robots/drone/simulator/pointmass3d_drone_model.cpp
@@ -163,9 +163,18 @@ namespace argos
       /*** attitude (roll, pitch, yaw) control ***/
       /* roll, pitch, yaw errors */
       CVector3 cOrientationError(cOrientationTarget - m_cOrientation);
+      /* Normalize yaw error to [-pi, pi] */
+      CRadians cOrientationYawError;
+      cOrientationYawError.SetValue(cOrientationError.GetZ());
+      cOrientationError.SetZ(cOrientationYawError.SignedNormalize().GetValue());
       /* desired  roll, pitch, yaw rates */
+      CVector3 cPrevTargetOrientationError = cOrientationTarget - m_cOrientationTargetPrev;
+      /* Normalize previous target orientation yaw error to [-pi, pi] */
+      CRadians cPrevTargetYawError;
+      cPrevTargetYawError.SetValue(cPrevTargetOrientationError.GetZ());
+      cPrevTargetOrientationError.SetZ(cPrevTargetYawError.SignedNormalize().GetValue());
       CVector3 cAngularVelocityTarget =
-         (cOrientationTarget - m_cOrientationTargetPrev) / GetPM3DEngine().GetPhysicsClockTick();
+         cPrevTargetOrientationError / GetPM3DEngine().GetPhysicsClockTick();
       /* previous desired roll, pitch, yaw values for the controllers */
       m_cOrientationTargetPrev = cOrientationTarget;
       /* rotational rate errors */


### PR DESCRIPTION
Problem description: 
    When using drones, first set
      robot.flight_system.set_target_pose(vector3(0,0,0), math.pi - 0.01) 
    and then set
      robot.flight_system.set_target_pose(vector3(0,0,0), math.pi + 0.01) 
instead of keep rotating, the drone tends to rotate back through the longer side to math.pi+0.1

I tweaked the Z component of orientation error and angular velocity error in drone pointmass model to make the drone rotates smoothly when jumping across the edge of Pi.
A small test scenario is enclosed
[vns.zip](https://github.com/ilpincy/argos3/files/10833262/vns.zip)
